### PR TITLE
feat(package): Developers should be able to run test coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             yarn test-ci
       - run:
           name: Run Jest and Collect Coverage Reports
-          command: yarn test-cov
+          command: yarn test-cov-ci
       - store_artifacts:
           path: coverage
 workflows:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ You will also see any lint errors in the console.
 Launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
+### `yarn test-cov`
+
+Runs the test coverage report in interactive watch mode.\
+For more information please refer to the react [Coverage Reporting](https://create-react-app.dev/docs/running-tests/#coverage-reporting) documentation.
+
 ### `yarn build`
 
 Builds the app for production to the `build` folder.\

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test-ci": "react-scripts test --watchAll=false",
-    "test-cov": "react-scripts test --watchAll=false --coverage",
+    "test-cov": "react-scripts test --coverage",
+    "test-cov-ci": "react-scripts test --watchAll=false --coverage",
     "eject": "react-scripts eject"
   },
   "browserslist": {


### PR DESCRIPTION
## Changes
1. New script runs tests and coverage reports in watch mode
2. Added docs to the process
3. CircleCI now has a dedicated command that only runs once

## Purpose
 Developers should be able to see code coverage around tested components. This is necessary if a developer is practicing TDD. 

## Approach
Separate out CircleCI from developers workflow.

## Testing

### Code coverage with TDD
1. Run `yarn test-cov`
2. Create failing test.
3. See failing test fail and code coverage set at 0%
4. Create passing component.
5. See test succeed and code coverage should be 100%
## Screenshots
![image](https://user-images.githubusercontent.com/398491/116281967-17dbef80-a73f-11eb-8142-2613ff7640b2.png)


### Closes #91 
