### PR TITLE
Add custom render for tests that will provide context

### DIFF
--- a/src/test.utils.tsx
+++ b/src/test.utils.tsx
@@ -1,0 +1,23 @@
+import { FC, ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { Provider as AuthProvider } from './context/auth.context';
+import { Provider as FlashMessageProvider } from './context/flashMessage.context';
+
+const AllTheProviders: FC = ({ children }) => {
+  return (
+    <AuthProvider>
+      <FlashMessageProvider>
+        {children}
+      </FlashMessageProvider>
+    </AuthProvider>
+  )
+}
+
+const customRender = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'queries'>
+) => render(ui, { wrapper: AllTheProviders, ...options })
+
+export * from '@testing-library/react'
+
+export { customRender as render }


### PR DESCRIPTION


## Changes
1. added custom render that will ensure the context providers are available when testing

## Purpose
Test in the same state that the end user will experience the application

## Approach
By wrapping the content of the render we are allowing it access to the methods and state within the various contexts

## Learning
React testing library documentation provided a clear example 

### Closes #137 
