### PR TITLE
fix(circleci): Docker and CI should have same version of modern node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     working_directory: ~/boilerplate-client-react
     docker:
-      - image: 'circleci/node:10-browsers'
+      - image: 'circleci/node:14-browsers'
     steps:
       - checkout
       - run: sudo apt-get update


### PR DESCRIPTION
## Changes
1. Update version of node from 10 -> 14

## Purpose
We should be using the same version of node on our Docker, CI, and Production servers.

## Approach
Change node version 10 to 14

### Closes #135
