### PR TITLE
fix(bug-report): Assignees should be the same across all templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Report a bug you're experiencing with app.
 title: ""
 labels: "bug"
-assignees: codysmith287
+assignees: ""
 ---
 
 ## Describe the bug


### PR DESCRIPTION
## Changes
1. Assignee should be blank

## Purpose
Cody is getting assigned to all bug reports. 

## Approach
Templates should be blank assigned. Thanks to @fluturecode for bringing this up. 

### Closes #225
