### PR TITLE
chore(.github): update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @codysmith287 @fluturecode @AramayisO
+* @michaelachrisco @fluturecode @AramayisO


### PR DESCRIPTION
## Changes
1. Updated list of code owners

## Purpose
The code owners list was updated to reflect the current core development team to ensure that people who are not currently assigned to the project are not constantly being added to PR reviews.

## Approach
The list of code owner is '.github/CODEOWNERS' was updated.

## Testing
No testing required.

### Closes #238
