### PR TITLE
Implemented `Delete Agent`

### DIFF
--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -1,3 +1,4 @@
 export * from './agency';
+export * from './agent';
 export * from './role';
 export * from './user';

--- a/src/features/agent-dashboard/agentApi.ts
+++ b/src/features/agent-dashboard/agentApi.ts
@@ -19,11 +19,22 @@ export const agentApi = createApi({
     },
   }),
 
+  tagTypes: ['Agent'],
+
   endpoints: (builder) => ({
     getAgents: builder.query<Agent[], void>({
       query: () => ({ url: '/' }),
-    })
-  })
+      providesTags: ['Agent'],
+    }),
+
+    deleteAgent: builder.mutation<void, number>({
+      query: (agentId) => ({
+        url: `/${agentId}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['Agent'],
+    }),
+  }),
 });
 
-export const { useGetAgentsQuery } = agentApi;
+export const { useGetAgentsQuery, useDeleteAgentMutation } = agentApi;

--- a/src/features/agent-dashboard/pages/AgentListView.tsx
+++ b/src/features/agent-dashboard/pages/AgentListView.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable no-console */
 import { CustomRenderer, GenericTable, TableHeader } from 'common/components';
 import ActionButton, { ActionButtonProps } from 'common/components/ActionButton';
+import { useConfirmationModal } from 'common/hooks';
+import { Agent } from 'common/models';
 import { FC } from 'react';
 import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
-import { useGetAgentsQuery } from '../agentApi';
+import { useDeleteAgentMutation, useGetAgentsQuery } from '../agentApi';
 
 type AgentTableItem = {
   id: number;
@@ -14,6 +16,21 @@ type AgentTableItem = {
 
 export const AgentListView: FC = () => {
   const { data: agents = [] } = useGetAgentsQuery();
+  const [deleteAgent] = useDeleteAgentMutation();
+  const { Modal: ConfirmationModal, openModal, closeModal } = useConfirmationModal();
+
+  const handleDelete = (agent: Agent) => {
+    const message = `Delete ${agent.name}?`;
+
+    const onConfirm = () => {
+      deleteAgent(agent.id);
+      closeModal();
+    };
+
+    const onCancel = () => closeModal();
+
+    openModal(message, onConfirm, onCancel);
+  };
 
   // Set up table headers
   const headers: TableHeader<AgentTableItem>[] = [
@@ -22,21 +39,18 @@ export const AgentListView: FC = () => {
   ];
 
   // Transform Agency objects returned from the API into the table item data format expected by the table.
-  const items: AgentTableItem[] = agents.map(
-    (agent) => ({
-      id: agent.id,
-      name: agent.name,
-      actions: [
-        { icon: 'edit', tooltipText: 'Edit', onClick: () => console.log(`Edit ${agent.name}`) },
-        {
-          icon: 'trash-alt',
-          tooltipText: 'Delete',
-          onClick: () => console.log(`Delete ${agent.name}`),
-        },
-      ],
-    }),
-    [agents],
-  );
+  const items: AgentTableItem[] = agents.map((agent) => ({
+    id: agent.id,
+    name: agent.name,
+    actions: [
+      { icon: 'edit', tooltipText: 'Edit', onClick: () => console.log(`Edit ${agent.name}`) },
+      {
+        icon: 'trash-alt',
+        tooltipText: 'Delete',
+        onClick: () => handleDelete(agent),
+      },
+    ],
+  }));
 
   const customRenderers: CustomRenderer<AgentTableItem>[] = [
     {
@@ -57,6 +71,7 @@ export const AgentListView: FC = () => {
         <Button>ADD AGENT</Button>
       </div>
       <GenericTable<AgentTableItem> headers={headers} items={items} customRenderers={customRenderers} />
+      <ConfirmationModal />
     </Container>
   );
 };


### PR DESCRIPTION
Handles #307 

## Changes
1. Added `DELETE` endpoint in `agentApi`.
2. Added 'provides/invalidates' tags to api endpoints to automatically refetch cached data after agent is deleted.
3. Modified `onClick` handler in `Delete` action button in the agent table to open up a confirmation modal to delete the agent.

## Purpose
To add the delete functionality to the agent list view.

## Pre-Testing TODOs
Run the `boilerplate-node-server'.

## Testing
1. Pull in the changes to your local copy of this branch and run `yarn start`.
2. Log in and click `delete agent`.
3. Log out and back in and check that the agent was deleted.
4. 
### Closes #307 
