### PR TITLE
fix(ActiveAccountForm): password should be hidden

### DIFF
--- a/src/components/activateAccountForm/index.tsx
+++ b/src/components/activateAccountForm/index.tsx
@@ -21,7 +21,11 @@ export const ActivateAccountForm: ActivateAccountFormType = ({ onSubmit, onCance
         <Title>Activate Account</Title>
         <Form.Group>
           <FormLabel htmlFor='newPassword'>New Password</FormLabel>
-          <Form.Control id='newPassword' type='password' {...register('newPassword')} placeholder='Enter new password' />
+          <Form.Control
+            id='newPassword'
+            type='password' {...register('newPassword')}
+            placeholder='Enter new password'
+          />
           {errors.newPassword?.message && <InputError role='alert'>{errors.newPassword?.message}</InputError>}
         </Form.Group>
         <Form.Group>


### PR DESCRIPTION
## Changes

1. `ActiveAccountForm` passwords should be hidden.

## Purpose
When a user activates their account, currently the field is plain text so passwords are visable. 

## Approach
Change type from text to password. 

I also went ahead and double checked our other forms. Looks like this is a one off.

### Closes #322 
