### PR TITLE
Phone Number Validation should be Human Readable

### DIFF
--- a/src/features/agent-dashboard/components/CreateAgentForm.tsx
+++ b/src/features/agent-dashboard/components/CreateAgentForm.tsx
@@ -32,7 +32,7 @@ const schema = yup.object().shape({
   phoneNumber: yup
     .string()
     .matches(Constants.patterns.US_PHONE_REGEX, {
-      message: 'Please enter a valid phone number. A Phone number must have 10 digits.',
+      message: 'Please enter a valid 10 digit phone number.',
       excludeEmptyString: true,
     })
     .required('Phone number is required.'),


### PR DESCRIPTION
## Changes
1. Made yup validation include 10 digit limit on phone numbers.
2. Modified form to correct phone number type

## Purpose
Allow users to get human readable errors within the form.

## Approach
Changes the form slightly to include more info on validation limits.

## Testing

1. Pull in the changes to your local copy of this branch and restart Docker.
2. Create new Agent
3. See validation error/success

## Screenshots
Success:
<img width="568" alt="Screen Shot 2021-09-20 at 11 46 55 AM" src="https://user-images.githubusercontent.com/398491/134058711-623bdf4b-d6fb-4222-922e-6b451621b5b5.png">


Failure:
<img width="568" alt="Screen Shot 2021-09-20 at 11 57 23 AM" src="https://user-images.githubusercontent.com/398491/134058843-8da1c3dc-a610-403a-b089-0bb41d5a6a15.png">



To get this project to MVP status and to make this 1-1 with the Angular project, I made the smallest possible change in order to get this working. However in most interfaces, I have seen other projects that Normalize Phone numbers in real time. Example here: https://stackoverflow.com/questions/55988065/react-how-to-format-phone-number-as-user-types 

A good Phase 2 feature. 

### Closes #330 
