### PR TITLE
feature(circleci): Set up starting server in background

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,7 @@ jobs:
       - run:
           name: Set up Dependencies
           command: |
-            export CI=true
             yarn install
-            yarn build
-          environment:
-            NODE_OPTIONS: --max_old_space_size=4096
       - run:
           name: Test Server
           command: |
@@ -27,7 +23,11 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4096
       - run:
-          name: Lint and Test Frontend
+          name: Build and Lint
+          command: |
+            yarn build         
+      - run:
+          name: Test Frontend
           command: |
             export CI=true
             yarn test-ci


### PR DESCRIPTION
## Changes
1. Separated out dependency management and background processes within CI build
2. Create background process that will contain server start via `yarn start`.

## Purpose
Verify `yarn start` works for all builds and sets up beginning of e2e/integration testing later on. 

## Approach
Update circleci config to run dependency management before all other operations as well as make sure yarn start works out of the box for every build. Any breakages will now be compartmentalized within their own separate workflow.

More info can be found here: https://app.circleci.com/pipelines/github/Shift3/boilerplate-client-react/853/workflows/bd8703fc-5d55-45c0-bc56-c359c7f24555/jobs/1302

### Closes #336 
### Closes #335
