### PR TITLE
Feature(FlashMessage): Notifications Top Screen

### DIFF
--- a/src/components/flashMessage/__tests__/__snapshots__/styled.spec.tsx.snap
+++ b/src/components/flashMessage/__tests__/__snapshots__/styled.spec.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FlashMessage Styled Components Should match the stored <FlashMessageContainer /> snapshot 1`] = `
+.c0 {
+  z-index: 1;
+}
+
 <div
-  className=""
+  className="c0"
 />
 `;

--- a/src/components/flashMessage/index.tsx
+++ b/src/components/flashMessage/index.tsx
@@ -22,21 +22,19 @@ export const FlashMessage: FC = () => {
   const { dismissNotification } = useDismissNotification();
 
   return (
-    <div className='position-relative'>
-      <FlashMessageContainer
-        className='position-absolute top-0 start-50 translate-middle-x'
-        data-testid='flashMessageContainer'>
-        {notifications.map((notification) => (
-          <Alert
-            key={notification.id}
-            variant={mapNotificationTypeToAlertVariant[notification.type]}
-            dismissible
-            onClose={() => dismissNotification(notification.id)}
-          >
-            {notification.message}
-          </Alert>
-        ))}
-      </FlashMessageContainer>
-    </div>
+    <FlashMessageContainer
+      className='position-absolute'
+      data-testid='flashMessageContainer'>
+      {notifications.map((notification) => (
+        <Alert
+          key={notification.id}
+          variant={mapNotificationTypeToAlertVariant[notification.type]}
+          dismissible
+          onClose={() => dismissNotification(notification.id)}
+        >
+          {notification.message}
+        </Alert>
+      ))}
+    </FlashMessageContainer>
   );
 };

--- a/src/components/flashMessage/styled.ts
+++ b/src/components/flashMessage/styled.ts
@@ -1,3 +1,5 @@
 import styled from 'styled-components';
 
-export const FlashMessageContainer = styled.div``;
+export const FlashMessageContainer = styled.div`
+z-index: 1;
+`;


### PR DESCRIPTION
## Changes
1. Errors and success messages now appear on the screen and do not move the entire screen down.

## Purpose
Warnings, Errors, and Success messages now occur on the same relative position within the page. 

## Approach
Small z index fix with a bootstrap 5 specific positioning class.

## Learning
Bootstrap 5 has some new class names for positioning. Pretty easy to use in this case.
https://getbootstrap.com/docs/5.0/utilities/position/

## Testing

1. Pull in the changes to your local copy of this branch and restart Docker.
2. Try to login with error email. 
3. See Notification.

## Screenshots

<img width="1026" alt="Screen Shot 2021-09-21 at 9 22 18 AM" src="https://user-images.githubusercontent.com/398491/134209061-42bacc1e-9d00-49cd-83ed-931a97931321.png">

### Closes #328 
