### PR TITLE
Added `resend activation toast` pop up

### DIFF
--- a/src/features/user-dashboard/pages/UserListView.tsx
+++ b/src/features/user-dashboard/pages/UserListView.tsx
@@ -42,6 +42,7 @@ export const UserListView: FC = () => {
     const onConfirm = () => {
       resendActivationEmail({ id: user.id });
       closeModal();
+      showSuccessNotification('Activation email has been sent.');
     };
 
     const onCancel = () => closeModal();


### PR DESCRIPTION
## Changes
1. Modified `UserListView.tsx`

## Purpose
When a super admin selects to resend the activation email, a toast pop up should appear to confirm the email has been sent.

## Testing
1. Pull in the changes to your local copy of this branch and run `yarn start`.
2. Go to the User list view, and select the email icon to resend an activation email.
3. Confirm after closing the modal, that the success notification appears.

## Screenshots
<img width="439" alt="Screen Shot 2021-09-28 at 2 36 10 PM" src="https://user-images.githubusercontent.com/59614789/135145943-becfb254-18fe-4749-a409-593387b6af7c.png">

### Closes #321 
