### PR TITLE
Fix error when adding user

### DIFF
--- a/src/features/user-dashboard/components/UserDetailForm.tsx
+++ b/src/features/user-dashboard/components/UserDetailForm.tsx
@@ -51,7 +51,6 @@ export const UserDetailForm: FC<Props> = ({
     mode: 'all',
     defaultValues: {
       ...defaultValues,
-      profilePicture: '',
       // Make dropdowns default to empty instead of first option if no valid default passed.
       role: {
         roleName: defaultValues?.role?.roleName ?? '',

--- a/src/features/user-dashboard/pages/CreateUserView.tsx
+++ b/src/features/user-dashboard/pages/CreateUserView.tsx
@@ -24,7 +24,7 @@ export const CreateUserView: FC = () => {
 
   const handleFormSubmit = async (data: FormData) => {
     try {
-      await createUser(data).unwrap();
+      await createUser({ ...data, profilePicture: '' }).unwrap();
       showSuccessNotification('User created.');
       history.push('/users');
     } catch (error) {


### PR DESCRIPTION
## Changes
1. Set value of `profilePicture` to empty string when creating user.

## Purpose
The `POST /users` endpoint of `boilerplate-server-node` expects the request body  to have a `profilePicture` property with a string value.

## Pre-Testing TODOs
Have `boilerplate-server-node` running.

## Testing
1. Pull in the changes to your local copy of this branch and start the app using `yarn start`.
2. Login and navigate to the create user form.
3. Test that you are able to create a new user without the error described in #352 .

### Closes #352
