### PR TITLE
Fix missing `key` prop warning

### DIFF
--- a/src/core/modules/navigation/presentation/sideNav.tsx
+++ b/src/core/modules/navigation/presentation/sideNav.tsx
@@ -40,7 +40,7 @@ export const SideNav: FC<NavProps> = ({ onNavToggle }) => {
               {navLinks
                 .filter((link) => link.canUserActivate)
                 .map((link) => (
-                  <NavLink link={link} />
+                  <NavLink key={link.label} link={link} />
                 ))}
             </Nav>
             <Nav>

--- a/src/core/modules/navigation/presentation/topNav.tsx
+++ b/src/core/modules/navigation/presentation/topNav.tsx
@@ -31,7 +31,7 @@ export const TopNav: FC<NavProps> = ({ onNavToggle }) => {
               {navLinks
                 .filter((link) => link.canUserActivate)
                 .map((link) => (
-                  <NavLink link={link} />
+                  <NavLink key={link.label} link={link} />
                 ))}
             </Nav>
             <Nav>


### PR DESCRIPTION
## Changes
1. Added `key` prop to mapped `NavLink`s in `TopNav` .
2. Added `key` prop to mapped `NavLink`s in `SideNav`.

## Purpose
When rendering a list in React, each item must have a unique `key` prop. We were getting a console warning as a result of these missing props.

## Pre-Testing TODOs
Have `boilerplate-server-node` running.

## Testing
1. Pull in the changes to your local copy of this branch.
2. Start the app using `yarn start`.
3. Login to the app and open up a browser console.
4. Refresh the page and check that the warning described in #356 is not getting logged.

### Closes #356 
