### PR TITLE
fix(README): Staging url should go to react

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This boilerplate has a [wiki](https://github.com/Shift3/boilerplate-client-react
 
 ## Staging URL
 
-<https://boilerplate-client-angular.shift3sandbox.com/>
+<https://boilerplate-client-react.shift3sandbox.com/>
 
 ## Quick Start
 


### PR DESCRIPTION
## Changes
1. Staging url should be react

## Purpose
Correct issue where staging url was ref. angular boilerplate

## Approach
Fix references. 

### Closes #365
