### PR TITLE
Updated `staging URL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This boilerplate has a [wiki](https://github.com/Shift3/boilerplate-client-react
 
 ## Staging URL
 
-<https://boilerplate-client-angular.shift3sandbox.com/>
+<https://boilerplate-client-react.shift3sandbox.com/>
 
 ## Quick Start
 


### PR DESCRIPTION
## Changes
1. Updated `README.md`

## Purpose
The README.md should directo the React Boilerplate sandbox at https://boilerplate-client-react.shift3sandbox.com

## Testing
1. Pull in the changes to your local copy of this branch and run `yarn start`.
2. Check that README.md directs to the React BP sandbox.

## Closes #389 