### PR TITLE
Developers should know how to contribute

### DIFF
--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,5 +1,7 @@
 # Contributing
 
+Looking to help out? Please take a look at [good first issue](https://github.com/Shift3/boilerplate-client-react/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) tagged issues.
+
 ## Contribution Standards
 
 - New features must be approved and pass architectural review. We want to thoughtfully design features and consider likely use-case scenarios.


### PR DESCRIPTION
## Changes
1. Added wiki page explaining our current contribution process. 

## Purpose
To provide a way for new developers to contribute to the project as well as cover contribution standards.

## Approach
Creates a separate wiki page. 

## Learning
I really like the readme-> wiki generator and will probably hook this into other projects as time permits. 

### References #49
### Closes #165