### PR TITLE
feat(wiki-home): Developers can navigate the home wiki page

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,1 +1,40 @@
 # React Boilerplate Documentation
+
+In this boilerplate, the wiki is setup to automatically be included and deployed within the [wiki folder](https://github.com/Shift3/boilerplate-client-react/tree/development/wiki). For more information please refer to [the README](https://github.com/Shift3/boilerplate-client-react#wiki-automation).
+
+- [React Boilerplate Documentation](#react-boilerplate-documentation)
+  - [Boilerplate Features](#boilerplate-features)
+  - [Boilerplate Project Structure](#boilerplate-project-structure)
+  - [Development Process](#development-process)
+  - [Resources](#resources)
+  - [Contributing](#contributing)
+
+## Boilerplate Features
+
+[Here](https://github.com/Shift3/boilerplate-client-react/wiki/Boilerplate-Features) is a list of features built into the React boilerplate.
+
+[Return to top](#top)
+
+## Boilerplate Project Structure
+
+[Here](https://github.com/Shift3/boilerplate-client-react/wiki/Boilerplate-Project-Structure) is an explanation of the project structure.
+
+[Return to top](#top)
+
+## Development Process
+
+[Here](https://github.com/Shift3/boilerplate-client-react/wiki/Development-Process) is an explanation of the development process.
+
+[Return to top](#top)
+
+## Resources
+
+[Here](https://github.com/Shift3/boilerplate-client-react/wiki/Resources) is a curated list of resources.
+
+[Return to top](#top)
+
+## Contributing
+
+[Here](https://github.com/Shift3/boilerplate-client-react/wiki/Contributing) are the guidelines for contributing to this boilerplate.
+
+[Return to top](#top)


### PR DESCRIPTION
## Changes
1. Add main Home wiki page. 

## Purpose
We currently do not have much in the main page of the wiki. We should expand to at least cover the other pages we have already created.  

## Approach
Adding more docs to the main wiki page.

## Testing
1. Pull down the pr and verify links are all present (excluding contributing which is covered in a previous PR). 

### References #49

### Closes #159
