### PR TITLE
Add `history` routing to changePassordForm cancel button

### DIFF
--- a/src/features/auth/components/changePasswordForm/index.tsx
+++ b/src/features/auth/components/changePasswordForm/index.tsx
@@ -20,9 +20,7 @@ export const ChangePasswordForm: ChangePasswordFormType = ({ onSubmit }) => {
 
   const history = useHistory();
 
-  const navigateToLogin = () => {
-    history.push('/auth/login');
-  };
+  const onCancel = () => history.goBack();
 
   // Trigger validation on first render.
   useEffect(() => {
@@ -71,7 +69,7 @@ export const ChangePasswordForm: ChangePasswordFormType = ({ onSubmit }) => {
         </Form.Control.Feedback>
       </Form.Group>
       <ButtonWrapper>
-        <CancelButton onClick={navigateToLogin}>CANCEL</CancelButton>
+        <CancelButton onClick={onCancel}>CANCEL</CancelButton>
         <SubmitButton type='submit' disabled={!isValid}>
           SUBMIT
         </SubmitButton>


### PR DESCRIPTION
## Changes
1. Modified `src/features/auth/components/changePasswordForm/index.tsx`

## Purpose
When a user selects `cancel` from the changePasswordForm they are logged out and routed to `/auth/login`.

## Pre-Testing TODOs
Make sure to run the `node server`.

## Testing
1. Pull in the changes to your local copy of this branch and run `yarn start`.
2. Log in and navigate to the `ChangePasswordForm`.
3. Click `cancel` and see that you were routed back to that last view you were in.

### Closes #450 
