### PR TITLE
Redirect root path to agent list view

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,11 +1,10 @@
 import { ErrorBoundary } from '@sentry/react';
 import { Routes as AgencyRoutes } from 'features/agency-dashboard/Routes';
 import { Routes as AgentRoutes } from 'features/agent-dashboard/Routes';
-import { DashboardPage } from 'features/auth/components/dashboardPage';
 import { PrivateRoute } from 'features/auth/components/privateRoute.tsx';
 import { Routes as UserRoutes } from 'features/user-dashboard/Routes';
 import { FC } from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import { GlobalStyle } from '../GlobalStyle';
 import AppTheme from 'utils/styleValues';
@@ -34,8 +33,10 @@ export const App: FC = () => (
           <PrivateRoute path='/agents' component={AgentRoutes} />
           <PrivateRoute path='/agencies' component={AgencyRoutes} requiredRoles={['Super Administrator']} />
           <PrivateRoute path='/users' component={UserRoutes} requiredRoles={['Admin', 'Super Administrator']} />
-          <PrivateRoute exact path='/' component={DashboardPage} />
-          <Route path='/' component={NotFoundView} />
+          <PrivateRoute exact path='/'>
+            <Redirect to='/agents' />
+          </PrivateRoute>
+          <Route component={NotFoundView} />
         </Switch>
       </HolyGrailLayout>
     </ThemeProvider>

--- a/src/features/auth/components/dashboardPage/index.tsx
+++ b/src/features/auth/components/dashboardPage/index.tsx
@@ -1,8 +1,0 @@
-import { FC } from 'react';
-import styled from 'styled-components';
-
-const DashboardPageContainer = styled.div``;
-
-export const DashboardPage: FC = () => {
-  return <DashboardPageContainer />;
-};


### PR DESCRIPTION
## Changes
1. Redirect user to agent list view if they navigate to the root path `path='/'`
2. Remove unused empty `DashboardPage` component.

## Purpose
The user should be redirected to a page with content when they try to navigate to the root path. Currently, the root path does not have any content and renders an empty page.

## Testing
1. Pull in the changes to your local copy of this branch.
2. Start the app using `yarn start`.
3. Log in using any user role.
4. Try to manually navigate to the root path `localhost:3000/` and ensure that the app redirects you to the Agent list view `localhost:3000/agents`.

### Closes #474 
