### PR TITLE
Remove `staging` & `additional resources` on `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,3 @@ const PersonForm = () => {
 ```
 
 For more information, see the [useForm](https://react-hook-form.com/api/useform) and [@hookform/resolvers](https://github.com/react-hook-form/resolvers) documentation.
-
-### Staging Build
-
-### Additional Resources


### PR DESCRIPTION
## Changes
1. Modified `README.md`

## Purpose
Our staging is listed previously in the first section of the `README.md`, and our additional resources are handled in the [`Wiki`](https://github.com/Shift3/boilerplate-client-react/wiki), therefore we can remove these headings.

### Closes #422