### PR TITLE
Form Prompts before user navigates away from dirty inputs.

### DIFF
--- a/src/common/components/FormPrompt/index.tsx
+++ b/src/common/components/FormPrompt/index.tsx
@@ -1,0 +1,15 @@
+import { Prompt } from "react-router-dom"
+
+type PromptProps = {
+    isDirty: boolean;
+    isSubmitting: boolean;
+}
+
+const FormPrompt = ({ isDirty, isSubmitting }: PromptProps): JSX.Element => {
+
+    return (
+        <Prompt when={isDirty && !isSubmitting} message="You have unsaved changes, are you sure you want to leave?" />
+    )
+}
+
+export default FormPrompt;

--- a/src/features/agency-dashboard/components/AgencyDetailForm.tsx
+++ b/src/features/agency-dashboard/components/AgencyDetailForm.tsx
@@ -5,6 +5,7 @@ import { FC, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { LoadingButton } from 'common/components/LoadingButton';
+import FormPrompt from 'common/components/FormPrompt';
 
 export type FormData = Pick<Agency, 'agencyName'>;
 
@@ -20,7 +21,7 @@ const schema = yup.object().shape({
 
 export const AgencyDetailForm: FC<Props> = ({ defaultValues = {}, onSubmit }) => {
   const {
-    formState: { errors, isValid, isSubmitting },
+    formState: { errors, isValid, isDirty, isSubmitting},
     handleSubmit,
     register,
     trigger,
@@ -43,6 +44,7 @@ export const AgencyDetailForm: FC<Props> = ({ defaultValues = {}, onSubmit }) =>
           SUBMIT
         </LoadingButton>
       </div>
+      <FormPrompt isDirty={isDirty} isSubmitting={isSubmitting} />
     </Form>
   );
 };

--- a/src/features/agent-dashboard/components/AgentDetailForm.tsx
+++ b/src/features/agent-dashboard/components/AgentDetailForm.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import FormPrompt from 'common/components/FormPrompt';
 import { PhoneInput } from 'common/components/PhoneInput';
 import { Agent } from 'common/models';
 import { ButtonWrapper, CancelButton, SubmitButton } from 'common/styles/button';
@@ -52,7 +53,7 @@ export const AgentDetailForm: FC<Props> = ({
 }) => {
   const {
     register,
-    formState: { errors, isValid },
+    formState: { errors, isValid, isDirty, isSubmitted },
     handleSubmit,
     trigger,
     control,
@@ -179,6 +180,7 @@ export const AgentDetailForm: FC<Props> = ({
           {submitButtonLabel}
         </SubmitButton>
       </ButtonWrapper>
+      <FormPrompt isDirty={isDirty} isSubmitting={isSubmitted} />
     </Form>
   );
 };

--- a/src/features/auth/components/ResetPasswordForm.tsx
+++ b/src/features/auth/components/ResetPasswordForm.tsx
@@ -5,6 +5,7 @@ import { Form } from 'react-bootstrap';
 import * as yup from 'yup';
 import { Constants } from 'utils/constants';
 import { LoadingButton } from 'common/components/LoadingButton';
+import FormPrompt from 'common/components/FormPrompt';
 
 export type FormData = {
   newPassword: string;
@@ -33,7 +34,7 @@ const schema: yup.SchemaOf<FormData> = yup.object().shape({
 
 export const ResetPasswordForm: FC<Props> = ({ onSubmit }) => {
   const {
-    formState: { errors, isValid, isSubmitting },
+    formState: { errors, isValid, isDirty, isSubmitting },
     handleSubmit,
     register,
     trigger,
@@ -79,6 +80,7 @@ export const ResetPasswordForm: FC<Props> = ({ onSubmit }) => {
           SUBMIT
         </LoadingButton>
       </div>
+      <FormPrompt isDirty={isDirty} isSubmitting={isSubmitting} />
     </Form>
   );
 };

--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -6,6 +6,7 @@ import * as yup from 'yup';
 import { Constants } from 'utils/constants';
 import { CancelButton } from 'common/styles/button';
 import { LoadingButton } from 'common/components/LoadingButton';
+import FormPrompt from 'common/components/FormPrompt';
 
 export type FormData = {
   email: string;
@@ -31,7 +32,7 @@ const schema: yup.SchemaOf<FormData> = yup.object().shape({
 
 export const SignUpForm: FC<Props> = ({ onSubmit, onCancel }) => {
   const {
-    formState: { errors, isValid, isSubmitting },
+    formState: { errors, isValid, isDirty, isSubmitting },
     handleSubmit,
     register,
     trigger,
@@ -113,6 +114,7 @@ export const SignUpForm: FC<Props> = ({ onSubmit, onCancel }) => {
       <div className='d-grid mt-3'>
         <CancelButton onClick={onCancel}>CANCEL</CancelButton>
       </div>
+      <FormPrompt isDirty={isDirty} isSubmitting={isSubmitting} />
     </Form>
   );
 };

--- a/src/features/auth/components/UpdateUserProfileForm.tsx
+++ b/src/features/auth/components/UpdateUserProfileForm.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { Constants } from 'utils/constants';
 import { LoadingButton } from 'common/components/LoadingButton';
+import FormPrompt from 'common/components/FormPrompt';
 
 export type FormData = {
   firstName: string;
@@ -25,7 +26,7 @@ const schema: yup.SchemaOf<FormData> = yup.object().shape({
 
 export const UpdateUserProfileForm: FC<Props> = ({ onSubmit, defaultValues }) => {
   const {
-    formState: { errors, isValid, isSubmitting },
+    formState: { errors, isValid, isDirty, isSubmitting },
     handleSubmit,
     register,
     trigger,
@@ -67,6 +68,7 @@ export const UpdateUserProfileForm: FC<Props> = ({ onSubmit, defaultValues }) =>
           UPDATE
         </LoadingButton>
       </div>
+      <FormPrompt isDirty={isDirty} isSubmitting={isSubmitting} />
     </Form>
   );
 };

--- a/src/features/auth/components/__tests__/ResetPasswordForm.spec.tsx
+++ b/src/features/auth/components/__tests__/ResetPasswordForm.spec.tsx
@@ -3,16 +3,21 @@ import userEvent from '@testing-library/user-event';
 import { ResetPasswordForm } from '../ResetPasswordForm';
 import { ThemeProvider } from 'styled-components';
 import AppTheme from 'utils/styleValues';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 const mockOnSubmit = jest.fn();
 
 describe('ResetPasswordForm', () => {
   beforeEach(async () => {
+    const history = createMemoryHistory();
     await act(async () => {
       render(
-        <ThemeProvider theme={AppTheme}>
-          <ResetPasswordForm onSubmit={mockOnSubmit} />
-        </ThemeProvider>,
+        <Router history={history}>
+          <ThemeProvider theme={AppTheme}>
+            <ResetPasswordForm onSubmit={mockOnSubmit} />
+          </ThemeProvider>,
+        </Router>
       );
     });
   });

--- a/src/features/auth/components/__tests__/SignUpForm.spec.tsx
+++ b/src/features/auth/components/__tests__/SignUpForm.spec.tsx
@@ -3,17 +3,22 @@ import userEvent from '@testing-library/user-event';
 import { SignUpForm } from '../SignUpForm';
 import { ThemeProvider } from 'styled-components';
 import AppTheme from 'utils/styleValues';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 const mockOnSubmit = jest.fn();
 const mockOnCancel = jest.fn();
 
 describe('SignupForm', () => {
   beforeEach(async () => {
+    const history = createMemoryHistory();
     await act(async () => {
       render(
-        <ThemeProvider theme={AppTheme}>
-          <SignUpForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
-        </ThemeProvider>,
+        <Router history={history}>
+          <ThemeProvider theme={AppTheme}>
+            <SignUpForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+          </ThemeProvider>,        
+        </Router>
       );
     });
     mockOnSubmit.mockReset();

--- a/src/features/auth/components/__tests__/UpdateUserProfileForm.spec.tsx
+++ b/src/features/auth/components/__tests__/UpdateUserProfileForm.spec.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { UpdateUserProfileForm } from '../UpdateUserProfileForm';
 import { ThemeProvider } from 'styled-components';
 import AppTheme from 'utils/styleValues';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 const mockOnSubmit = jest.fn();
 const defaultValues = {
@@ -13,11 +15,14 @@ const defaultValues = {
 
 describe('UpdateUserProfileForm', () => {
   beforeEach(async () => {
+    const history = createMemoryHistory();
     await act(async () => {
       render(
-        <ThemeProvider theme={AppTheme}>
-          <UpdateUserProfileForm onSubmit={mockOnSubmit} defaultValues={defaultValues} />
-        </ThemeProvider>,
+        <Router history={history}>
+          <ThemeProvider theme={AppTheme}>
+            <UpdateUserProfileForm onSubmit={mockOnSubmit} defaultValues={defaultValues} />
+          </ThemeProvider>,
+        </Router>
       );
     });
     mockOnSubmit.mockReset();

--- a/src/features/user-dashboard/components/ChangePasswordForm.tsx
+++ b/src/features/user-dashboard/components/ChangePasswordForm.tsx
@@ -5,6 +5,7 @@ import { Form } from 'react-bootstrap';
 import * as yup from 'yup';
 import { Constants } from 'utils/constants';
 import { LoadingButton } from 'common/components/LoadingButton';
+import FormPrompt from 'common/components/FormPrompt';
 
 export type FormData = {
   oldPassword: string;
@@ -37,7 +38,7 @@ const schema: yup.SchemaOf<FormData> = yup.object().shape({
 
 export const ChangePasswordForm: FC<Props> = ({ onSubmit }) => {
   const {
-    formState: { errors, isValid, isSubmitting },
+    formState: { errors, isValid, isDirty, isSubmitting },
     handleSubmit,
     register,
     trigger,
@@ -103,6 +104,7 @@ export const ChangePasswordForm: FC<Props> = ({ onSubmit }) => {
           SUBMIT
         </LoadingButton>
       </div>
+      <FormPrompt isDirty={isDirty} isSubmitting={isSubmitting} />
     </Form>
   );
 };

--- a/src/features/user-dashboard/components/UserDetailForm.tsx
+++ b/src/features/user-dashboard/components/UserDetailForm.tsx
@@ -5,6 +5,7 @@ import Form from 'react-bootstrap/Form';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { LoadingButton } from 'common/components/LoadingButton';
+import FormPrompt from 'common/components/FormPrompt';
 
 export type FormData = Pick<User, 'email' | 'firstName' | 'lastName' | 'profilePicture' | 'role' | 'agency'>;
 
@@ -30,7 +31,7 @@ const schema = yup.object().shape({
 
 export const UserDetailForm: FC<Props> = ({ availableRoles, availableAgencies, defaultValues = {}, onSubmit }) => {
   const {
-    formState: { errors, isValid, isSubmitting },
+    formState: { errors, isValid, isDirty, isSubmitting },
     handleSubmit,
     register,
     setValue,
@@ -135,6 +136,7 @@ export const UserDetailForm: FC<Props> = ({ availableRoles, availableAgencies, d
           SUBMIT
         </LoadingButton>
       </div>
+      <FormPrompt isDirty={isDirty} isSubmitting={isSubmitting} />
     </Form>
   );
 };

--- a/src/features/user-dashboard/components/__tests__/ChangePasswordForm.spec.tsx
+++ b/src/features/user-dashboard/components/__tests__/ChangePasswordForm.spec.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from 'styled-components';
 import theme from 'utils/styleValues';
 import { ChangePasswordForm, FormData } from '../ChangePasswordForm';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 describe('ChangePasswordForm', () => {
   const validFormData: FormData = {
@@ -12,17 +14,19 @@ describe('ChangePasswordForm', () => {
   };
 
   const mockOnSubmit = jest.fn();
-  const mockOnCancel = jest.fn();
 
   beforeEach(async () => {
     // The render() needs to be wrapped in act() because the component has a useEffect() hook
     // that triggers form validation and modifies the form state right after the first render.
     // act() ensures that this update is processed and applied to the DOM before running tests.
     await act(async () => {
+      const history = createMemoryHistory();
       render(
-        <ThemeProvider theme={theme}>
-          <ChangePasswordForm onSubmit={mockOnSubmit} />
-        </ThemeProvider>,
+        <Router history={history}>
+          <ThemeProvider theme={theme}>
+            <ChangePasswordForm onSubmit={mockOnSubmit} />
+          </ThemeProvider>,
+        </Router>
       );
     });
 


### PR DESCRIPTION
## Changes
1. Prompts before users navigate away from Forms
2. Adding the re-usable FormPrompt component so we can add the prompt to any forms we create in the future.
​
## Purpose
The purpose of this feature is to protect users from losing data from accidentally hitting the back button, and providing a better user experience.
​
## Approach
This change adds in prompt that only activates if you press any element that navigates the user away from their current page. This does not include the Submit buttons.
​
## Learning
I was able to accomplish the desired results by studying the following resources.
[isDirty - React Hook Form Docs](https://react-hook-form.com/api/useformstate)
[Prompt - React Router Docs](https://v5.reactrouter.com/core/api/Prompt)
​
## Testing
1. Pull in the changes to your local copy of this branch and restart Docker
2. Login to the application
3. Press "Add Agent"
4. Start filling out the form
5. Press any element that will navigate you away from the current page
6. _**ASSERT**_ Prompt appears stating you have unsaved changes
7. _**ASSERT**_ Once you select "Ok" you are navigated away from the current page
8. _**ASSERT**_ If you select "Cancel" you are redirected to the top of the current page without losing any form data.
​
`Follow this same process with the Change Password, User Profile, and Add Agent forms`
​
### Closes #496 