### PR TITLE
feat,refactor(user-profile): redesigns user profile page

### DIFF
--- a/src/common/api/userApi.ts
+++ b/src/common/api/userApi.ts
@@ -17,14 +17,16 @@ export type CreateUserRequest = Pick<User, 'email' | 'firstName' | 'lastName' | 
 export type ForgotPasswordRequest = Pick<User, 'email'>;
 export type ForgotPasswordResponse = { message: string };
 export type ResendActivationEmailRequest = Pick<User, 'id'>;
+export type ResendChangeEmailVerificationEmailRequest = Pick<User, 'id'>;
 export type ResetPasswordRequest = {
   token: string;
   newPassword: string;
   confirmPassword: string;
 };
 export type SignUpRequest = Pick<User, 'email' | 'firstName' | 'lastName'>;
-export type UpdateProfileRequest = Pick<User, 'id' | 'email' | 'firstName' | 'lastName' | 'profilePicture'>;
+export type UpdateProfileRequest = Pick<User, 'id' | 'firstName' | 'lastName' | 'profilePicture'>;
 export type UpdateUserRequest = Pick<User, 'id' | 'email' | 'firstName' | 'lastName' | 'profilePicture' | 'role'>;
+export type UserChangeEmailRequest = Pick<User, 'id' | 'email'>;
 
 export const userApi = createApi({
   reducerPath: 'userApi',
@@ -124,9 +126,25 @@ export const userApi = createApi({
       invalidatesTags: ['User'],
     }),
 
+    requestChangeEmail: builder.mutation<User, UserChangeEmailRequest>({
+      query: ({ id, ...payload }) => ({
+        url: `/users/request-change-email/${id}`,
+        method: `PUT`,
+        body: payload,
+      }),
+      invalidatesTags: ['User'],
+    }),
+
     resendActivationEmail: builder.mutation<void, ResendActivationEmailRequest>({
       query: ({ id }) => ({
         url: `/users/resend-activation-email/${id}`,
+        method: 'GET',
+      }),
+    }),
+
+    resendChangeEmailVerificationEmail: builder.mutation<void, ResendChangeEmailVerificationEmailRequest>({
+      query: ({ id }) => ({
+        url: `/users/resend-change-email-verification-email/${id}`,
         method: 'GET',
       }),
     }),
@@ -141,7 +159,9 @@ export const {
   useForgotPasswordMutation,
   useGetUsersQuery,
   useGetUserByIdQuery,
+  useRequestChangeEmailMutation,
   useResendActivationEmailMutation,
+  useResendChangeEmailVerificationEmailMutation,
   useResetPasswordMutation,
   useSignUpMutation,
   useUpdateProfileMutation,

--- a/src/common/models/testing-factories/user-factory.ts
+++ b/src/common/models/testing-factories/user-factory.ts
@@ -13,4 +13,5 @@ export const UserFactory = Factory.define<User>(({ sequence, associations }) => 
   profilePicture: Faker.internet.avatar(),
   agency: associations.agency ?? AgencyFactory.build(),
   role: associations.role ?? RoleFactory.build(),
+  newEmail: Faker.internet.email(),
 }));

--- a/src/common/models/user.ts
+++ b/src/common/models/user.ts
@@ -10,4 +10,5 @@ export interface User {
   profilePicture: string | null;
   agency: Agency;
   role: Role;
+  newEmail: string | null;
 }

--- a/src/features/auth/components/UpdateUserEmailForm.tsx
+++ b/src/features/auth/components/UpdateUserEmailForm.tsx
@@ -1,0 +1,54 @@
+import { FC, useEffect } from 'react';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import { Constants } from 'utils/constants';
+import { LoadingButton } from 'common/components/LoadingButton';
+
+export type UserEmailFormData = {
+  email: string;
+};
+
+type Props = {
+  onSubmit: (data: UserEmailFormData) => void;
+  defaultValues?: Partial<UserEmailFormData>;
+};
+
+const schema: yup.SchemaOf<UserEmailFormData> = yup.object().shape({
+  email: yup.string().required(Constants.errorMessages.EMAIL_REQUIRED).email(Constants.errorMessages.INVALID_EMAIL),
+});
+
+export const UpdateUserEmailForm: FC<Props> = ({ onSubmit, defaultValues }) => {
+  const {
+    formState: { errors, isValid, isSubmitting },
+    handleSubmit,
+    register,
+    trigger,
+  } = useForm({
+    resolver: yupResolver(schema),
+    mode: 'all',
+    defaultValues,
+  });
+
+  useEffect(() => {
+    trigger();
+  }, [trigger]);
+
+  return (
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form.Group>
+        <Form.Label htmlFor='email'>Email</Form.Label>
+        <Form.Control id='email' type='email' {...register('email')} isInvalid={!!errors.email} />
+        <Form.Control.Feedback type='invalid' role='alert'>
+          {errors.email?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+      <div className='d-grid gap-2 mt-3'>
+        <LoadingButton disabled={!isValid} loading={isSubmitting}>
+          UPDATE
+        </LoadingButton>
+      </div>
+    </Form>
+  );
+};

--- a/src/features/auth/components/UpdateUserProfileForm.tsx
+++ b/src/features/auth/components/UpdateUserProfileForm.tsx
@@ -9,7 +9,6 @@ import { LoadingButton } from 'common/components/LoadingButton';
 export type FormData = {
   firstName: string;
   lastName: string;
-  email: string;
 };
 
 type Props = {
@@ -20,7 +19,6 @@ type Props = {
 const schema: yup.SchemaOf<FormData> = yup.object().shape({
   firstName: yup.string().trim().required(Constants.errorMessages.FIRST_NAME_REQUIRED),
   lastName: yup.string().trim().required(Constants.errorMessages.LAST_NAME_REQUIRED),
-  email: yup.string().required(Constants.errorMessages.EMAIL_REQUIRED).email(Constants.errorMessages.INVALID_EMAIL),
 });
 
 export const UpdateUserProfileForm: FC<Props> = ({ onSubmit, defaultValues }) => {
@@ -53,13 +51,6 @@ export const UpdateUserProfileForm: FC<Props> = ({ onSubmit, defaultValues }) =>
         <Form.Control id='lastName' type='text' {...register('lastName')} isInvalid={!!errors.lastName} />
         <Form.Control.Feedback type='invalid' role='alert'>
           {errors.lastName?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
-      <Form.Group>
-        <Form.Label htmlFor='email'>Email</Form.Label>
-        <Form.Control id='email' type='email' {...register('email')} isInvalid={!!errors.email} />
-        <Form.Control.Feedback type='invalid' role='alert'>
-          {errors.email?.message}
         </Form.Control.Feedback>
       </Form.Group>
       <div className='d-grid gap-2 mt-3'>

--- a/src/features/auth/pages/UpdateUserProfilePage.tsx
+++ b/src/features/auth/pages/UpdateUserProfilePage.tsx
@@ -1,14 +1,22 @@
+import Button from 'react-bootstrap/Button';
+import styled from 'styled-components';
 import { FC } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query';
 import { useAuth } from 'features/auth/hooks';
-import { useUpdateProfileMutation } from 'common/api/userApi';
+import { User } from 'common/models';
+import {
+  useRequestChangeEmailMutation,
+  useResendChangeEmailVerificationEmailMutation,
+  useUpdateProfileMutation,
+} from 'common/api/userApi';
 import { handleApiError } from 'common/api/handleApiError';
 import { useAppDispatch } from 'app/redux';
 import { authSlice } from 'features/auth/authSlice';
 import * as notificationService from 'common/services/notification';
 import * as authLocalStorage from 'features/auth/authLocalStorage';
 import { FormData, UpdateUserProfileForm } from '../components/UpdateUserProfileForm';
+import { UserEmailFormData, UpdateUserEmailForm } from '../components/UpdateUserEmailForm';
 import { PageWrapper } from 'common/styles/page';
 import { StyledFormWrapper, Title } from 'common/styles/form';
 
@@ -21,6 +29,8 @@ export const UpdateUserProfilePage: FC = () => {
   const { id } = useParams<RouteParams>();
   const { token, user } = useAuth();
   const [updateProfile] = useUpdateProfileMutation();
+  const [requestChangeEmail] = useRequestChangeEmailMutation();
+  const [resendChangeEmailVerificationEmail] = useResendChangeEmailVerificationEmailMutation();
   const dispatch = useAppDispatch();
 
   const onSubmit = async (formData: FormData) => {
@@ -38,6 +48,46 @@ export const UpdateUserProfilePage: FC = () => {
     }
   };
 
+  const onSubmitRequestEmailChange = async (formData: UserEmailFormData) => {
+    const data = { id: Number(id), ...formData };
+
+    try {
+      const updatedUser = await requestChangeEmail(data).unwrap();
+      const newAuth = { token, user: updatedUser };
+      dispatch(authSlice.actions.userLoggedIn(newAuth));
+      authLocalStorage.saveAuthState(newAuth);
+      notificationService.showSuccessMessage('Email Verification sent. Follow the instructions in the email to proceed.');
+      history.push('/agents');
+    } catch (error) {
+      handleApiError(error as FetchBaseQueryError);
+    }
+  }
+
+  const Wrapper = styled.div`
+    margin-bottom: 20px;
+  `;
+
+  const Text = styled.div`
+    color: ${(props) => props.theme.forms.textColor};
+    margin: 20px auto 0;
+  `;
+
+  const ResendVerificationEmailButton = styled(Button)`
+    color: ${(props) => props.theme.buttons.submitTextColor};
+    background-color: ${(props) => props.theme.buttons.submitBackgroundColor};
+    border-color: ${(props) => props.theme.buttons.submitBorderColor};
+    width: 100%;
+  `;
+
+  const handleResendChangeEmailVerificationEmail = () => {
+    try {
+      resendChangeEmailVerificationEmail({ id: Number(id) });
+      notificationService.showSuccessMessage('Change Email verification email has been sent.');
+    } catch (error) {
+      handleApiError(error as FetchBaseQueryError);
+    }
+  }
+
   return (
     <PageWrapper>
       <StyledFormWrapper>
@@ -47,9 +97,34 @@ export const UpdateUserProfilePage: FC = () => {
           defaultValues={{
             firstName: user?.firstName ?? '',
             lastName: user?.lastName ?? '',
-            email: user?.email ?? '',
           }}
         />
+      </StyledFormWrapper>
+
+      <StyledFormWrapper>
+        <Title>Update Email</Title>
+          { user?.newEmail && (
+            <Wrapper>
+              <Text>
+                <p data-testid='updateUserExistingEmailChangeInfoContent'>An email change has already been requested for your account.</p>
+              </Text>
+              <ResendVerificationEmailButton
+                data-testid='resendVerificationEmailButton'
+                onClick={ handleResendChangeEmailVerificationEmail }
+              >
+                RESEND VERIFICATION EMAIL
+              </ResendVerificationEmailButton>
+              <Text>
+                <p data-testid='updateUserEmailChangeInfoContent'>If you would like to request email change to another email, enter the new email below.</p>
+              </Text>
+            </Wrapper>
+          )}
+          <UpdateUserEmailForm
+            onSubmit={onSubmitRequestEmailChange}
+            defaultValues={{
+              email: user?.email ?? '',
+            }}
+          />
       </StyledFormWrapper>
     </PageWrapper>
   );


### PR DESCRIPTION
## Changes
1. Creates a new `UpdateUserEmailForm` component that renders a form with `email` input field.
2. Creates a request type `UserChangeEmailRequest`, endpoints & mutations in the `userApi`.
3. Refactors `UpdateUserProfileForm` component to remove `email` field.
4. Refactors `UpdateUserProfilePage` to render both forms.
5. Notifies the user if an email change has already been requested.
6. Allows the user to resend the verification email if an email change request is already requested. 

## Purpose
Redesign the user profile page to have separate forms to manage user profile & email.

## Pre-Testing TODOs
Use `ps-364-user-email-change` branch on the node boilerplate to test this PR.

## Testing
1. Pull in the changes to your local copy of this branch and restart Docker.
2. 
3.

## Screenshots

### Closes #514 
