### PR TITLE
feat(codeowners): Update codeowners to refect team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @DropsOfSerenity @fluturecode @AramayisO
+* @DropsOfSerenity @AramayisO @joshwingreene


### PR DESCRIPTION
## Changes

  1. Update  CODEOWNERs file 

## Purpose
Technically @DropsOfSerenity is already the PM and Lead of the boilerplates as of last Thursday but this is to make it a bit more official. Ill still be around for any S&P initiatives and questions/concerns.

## Approach

Change CODEOWNERs file to reflect current project members. 

### Closes #520
