### PR TITLE
Don't show Add Agent button unless user has permissions.

### DIFF
--- a/src/features/agent-dashboard/pages/AgentListView.tsx
+++ b/src/features/agent-dashboard/pages/AgentListView.tsx
@@ -62,14 +62,17 @@ export const AgentListView: FC = () => {
             <NoContent>
               <FontAwesomeIcon className='text-muted' size='2x' icon={['fas', 'stethoscope']} />
               <p className='lead mb-0'>No Agents</p>
-              <p className='text-muted'>
-                Get started by creating a new agent.
-              </p>
-              <Link to='/agents/create-agent'>
-                <SecondaryButton>
-                  Add Agent
-                </SecondaryButton>
-              </Link>
+
+              <HasPermission perform='agent:create'>
+                <p className='text-muted'>
+                  Get started by creating a new agent.
+                </p>
+                <Link to='/agents/create-agent'>
+                  <SecondaryButton>
+                    Add Agent
+                  </SecondaryButton>
+                </Link>
+              </HasPermission>
             </NoContent>
           )}
           </WithLoadingOverlay>


### PR DESCRIPTION
In the redesign, I missed wrapping the "Add Agent" button I added in a permission helper.