### PR TITLE
Fixes the user/agent pre-population data issue

### DIFF
--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -1,12 +1,10 @@
 import { SortOrder } from 'common/models/sorting';
 import { ReactElement, useEffect } from 'react';
 import { Column, useFlexLayout, usePagination, useSortBy, useTable } from 'react-table';
-import { WithLoadingOverlay } from 'common/components/LoadingSpinner';
 import { Paginator } from './Paginator';
 import { SortIndicator } from './SortIndicator';
 
 export type DataTableProps<D extends Record<string, unknown>> = {
-  isLoading: boolean;
   columns: Column<D>[];
   data: D[];
   onRowClick?: (item: D) => void;
@@ -28,7 +26,6 @@ export type DataTableProps<D extends Record<string, unknown>> = {
 export const DataTable = <D extends Record<string, unknown>>({
   columns,
   data,
-  isLoading,
   onRowClick,
   pagination,
   sorting,
@@ -127,70 +124,68 @@ export const DataTable = <D extends Record<string, unknown>>({
   );
 
   return (
-    <WithLoadingOverlay isLoading={isLoading} containerHasRoundedCorners containerBorderRadius='6px'>
-      <div className='d-flex flex-column'>
-        <div className='table' {...getTableProps()}>
-          <div className='thead'>
-            {headerGroups.map(headerGroup => (
-              <div className='tr' {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map(column => (
-                  <>
-                    {sortByEnabled && column.canSort ? (
-                      // Add the sorting props to control sorting and sort direction indicator.
-                      <div className='th' {...column.getHeaderProps(column.getSortByToggleProps())}>
-                        {column.render('Header')}{' '}
-                        <SortIndicator isSorted={column.isSorted} isDesc={column.isSortedDesc} />
-                      </div>
-                    ) : (
-                      <div className='th' {...column.getHeaderProps()}>
-                        {column.render('Header')}
-                      </div>
-                    )}
-                  </>
-                ))}
-              </div>
-            ))}
-          </div>
-          <div className='tbody' {...getTableBodyProps()}>
-            {tableRows.map(row => {
-              prepareRow(row);
-              return (
-                <div
-                  className='tr'
-                  aria-hidden='true'
-                  onClick={() => {
-                    if ( onRowClick) onRowClick(row.original);
-                  }}
-                  {...row.getRowProps()}
-                >
-                  {row.cells.map(cell => {
-                    return (
-                      <div className='td' { ...cell.getCellProps() }>
-                        {cell.render('Cell')}
-                      </div>
-                    );
-                  })}
-                </div>
-              );
-            })}
-          </div>
+    <div className='d-flex flex-column'>
+      <div className='table' {...getTableProps()}>
+        <div className='thead'>
+          {headerGroups.map(headerGroup => (
+            <div className='tr' {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map(column => (
+                <>
+                  {sortByEnabled && column.canSort ? (
+                    // Add the sorting props to control sorting and sort direction indicator.
+                    <div className='th' {...column.getHeaderProps(column.getSortByToggleProps())}>
+                      {column.render('Header')}{' '}
+                      <SortIndicator isSorted={column.isSorted} isDesc={column.isSortedDesc} />
+                    </div>
+                  ) : (
+                    <div className='th' {...column.getHeaderProps()}>
+                      {column.render('Header')}
+                    </div>
+                  )}
+                </>
+              ))}
+            </div>
+          ))}
         </div>
-        {/* If the usePagination plugin is enabled, render a paginator to allow users to page through the data. */}
-        {paginationEnabled && (
-          <Paginator
-            page={pageIndex + pagination.basePage}
-            pageSize={pageSize}
-            count={pagination.count}
-            pageCount={pageCount}
-            pageSizeOptions={pagination.pageSizeOptions}
-            hasPreviousPage={canPreviousPage}
-            hasNextPage={canNextPage}
-            onPreviousPageClick={previousPage}
-            onNextPageClick={nextPage}
-            onPageSizeChange={setPageSize}
-          />
-        )}
+        <div className='tbody' {...getTableBodyProps()}>
+          {tableRows.map(row => {
+            prepareRow(row);
+            return (
+              <div
+                className='tr'
+                aria-hidden='true'
+                onClick={() => {
+                  if (onRowClick) onRowClick(row.original);
+                }}
+                {...row.getRowProps()}
+              >
+                {row.cells.map(cell => {
+                  return (
+                    <div className='td' {...cell.getCellProps()}>
+                      {cell.render('Cell')}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
       </div>
-    </WithLoadingOverlay>
+      {/* If the usePagination plugin is enabled, render a paginator to allow users to page through the data. */}
+      {paginationEnabled && (
+        <Paginator
+          page={pageIndex + pagination.basePage}
+          pageSize={pageSize}
+          count={pagination.count}
+          pageCount={pageCount}
+          pageSizeOptions={pagination.pageSizeOptions}
+          hasPreviousPage={canPreviousPage}
+          hasNextPage={canNextPage}
+          onPreviousPageClick={previousPage}
+          onNextPageClick={nextPage}
+          onPageSizeChange={setPageSize}
+        />
+      )}
+    </div>
   );
 };

--- a/src/common/components/LoadingSpinner/WithLoadingOverlay.tsx
+++ b/src/common/components/LoadingSpinner/WithLoadingOverlay.tsx
@@ -1,41 +1,49 @@
 import { CenteredSpinnerContainer, DimmableContent } from 'common/styles/utilities';
 import { FC, useEffect, useState } from 'react';
+import { NoContent } from '../Common';
 import { LoadingSpinner } from './LoadingSpinner';
 
 export type Props = {
   isLoading: boolean;
+  isInitialLoad: boolean;
   containerHasRoundedCorners: boolean;
   containerBorderRadius: string;
 };
 
-export const WithLoadingOverlay: FC<Props> = ({ isLoading, containerHasRoundedCorners, containerBorderRadius, children }) => {
-
+export const WithLoadingOverlay: FC<Props> = ({
+  isLoading,
+  isInitialLoad,
+  containerHasRoundedCorners,
+  containerBorderRadius,
+  children,
+}) => {
   const [isDelayComplete, setIsDelayComplete] = useState(false);
 
-  useEffect(
-    () => {
-      if (!isLoading) {
-        setTimeout(() => {
-          setIsDelayComplete(true);
-        }, 
-        250);
-      } else {
-        setIsDelayComplete(false);
-      }
-    },
-    [isLoading],
-  );
+  useEffect(() => {
+    if (!isLoading) {
+      setTimeout(() => {
+        setIsDelayComplete(true);
+      }, 250);
+    }
+    if (isLoading) {
+      setIsDelayComplete(false);
+    }
+  }, [isLoading]);
 
   return (
-    <DimmableContent dim={!isDelayComplete} containerHasRoundedCorners={containerHasRoundedCorners} containerBorderRadius={containerBorderRadius}>
-      { !isDelayComplete ? 
-        <CenteredSpinnerContainer>
-          <LoadingSpinner />
-        </CenteredSpinnerContainer> :
-        null
-      }
-      {children}
+    <DimmableContent
+      dim={!isDelayComplete}
+      containerHasRoundedCorners={containerHasRoundedCorners}
+      containerBorderRadius={containerBorderRadius}
+    >
+      {!isDelayComplete ? (
+        <>
+          <CenteredSpinnerContainer>
+            <LoadingSpinner />
+          </CenteredSpinnerContainer>
+        </>
+      ) : null}
+      {isInitialLoad ? <NoContent /> : children}
     </DimmableContent>
   );
-}
-
+};

--- a/src/features/agent-dashboard/pages/AgentListView.tsx
+++ b/src/features/agent-dashboard/pages/AgentListView.tsx
@@ -61,46 +61,6 @@ export const AgentListView: FC = () => {
     [],
   );
 
-  const renderDataTableOrNoAgentsView = (count: number) => {
-    if (count !== 0) {
-      return (
-        <DataTable<AgentTableItem>
-          columns={columns}
-          data={tableData}
-          onRowClick={item => navigate(`/agents/update-agent/${item.id}`)}
-          pagination={{
-            basePage: 1,
-            page,
-            pageSize,
-            count: data?.meta.count || 0,
-            pageCount: data?.meta.pageCount || 0,
-            pageSizeOptions: [5, 10, 25, 50, 100],
-            onPageChange: getPage,
-            onPageSizeChange: changePageSize,
-          }}
-          sorting={{
-            onSortByChange: changeSortBy,
-          }}
-          isLoading={isFetching}
-        />
-      );
-    }
-
-    return (
-      <NoContent>
-        <FontAwesomeIcon className='text-muted' size='2x' icon={['fas', 'stethoscope']} />
-        <p className='lead mb-0'>No Agents</p>
-
-        <HasPermission perform='agent:create'>
-          <p className='text-muted'>Get started by creating a new agent.</p>
-          <Link to='/agents/create-agent'>
-            <SecondaryButton>Add Agent</SecondaryButton>
-          </Link>
-        </HasPermission>
-      </NoContent>
-    );
-  };
-
   return (
     <Container>
       <PageHeader>
@@ -126,8 +86,44 @@ export const AgentListView: FC = () => {
       />
       <TableCard>
         <Card.Body>
-          <WithLoadingOverlay isLoading={isPageLoading} containerHasRoundedCorners containerBorderRadius='6px'>
-            {data?.meta ? renderDataTableOrNoAgentsView(data.meta.count) : <NoContent />}
+          <WithLoadingOverlay
+            isLoading={isPageLoading || isFetching}
+            isInitialLoad={isPageLoading && isFetching}
+            containerHasRoundedCorners
+            containerBorderRadius='6px'
+          >
+            {data?.meta.count !== 0 ? (
+              <DataTable<AgentTableItem>
+                columns={columns}
+                data={tableData}
+                onRowClick={item => navigate(`/agents/update-agent/${item.id}`)}
+                pagination={{
+                  basePage: 1,
+                  page,
+                  pageSize,
+                  count: data?.meta.count || 0,
+                  pageCount: data?.meta.pageCount || 0,
+                  pageSizeOptions: [5, 10, 25, 50, 100],
+                  onPageChange: getPage,
+                  onPageSizeChange: changePageSize,
+                }}
+                sorting={{
+                  onSortByChange: changeSortBy,
+                }}
+              />
+            ) : (
+              <NoContent>
+                <FontAwesomeIcon className='text-muted' size='2x' icon={['fas', 'stethoscope']} />
+                <p className='lead mb-0'>No Agents</p>
+
+                <HasPermission perform='agent:create'>
+                  <p className='text-muted'>Get started by creating a new agent.</p>
+                  <Link to='/agents/create-agent'>
+                    <SecondaryButton>Add Agent</SecondaryButton>
+                  </Link>
+                </HasPermission>
+              </NoContent>
+            )}
           </WithLoadingOverlay>
         </Card.Body>
       </TableCard>

--- a/src/features/agent-dashboard/pages/UpdateAgentView.tsx
+++ b/src/features/agent-dashboard/pages/UpdateAgentView.tsx
@@ -19,7 +19,7 @@ export const UpdateAgentView: FC = () => {
   const { id } = useParams<RouteParams>();
   const navigate = useNavigate();
   const [updateAgent] = useUpdateAgentMutation();
-  const { data: agent, isLoading: isLoadingAgent, error } = useGetAgentByIdQuery(id!);
+  const { data: agent, isLoading: isLoadingAgent, isFetching, error } = useGetAgentByIdQuery(id!);
   const [submissionError, setSubmissionError] = useState<ServerValidationErrors<FormData> | null>(null);
 
   useEffect(() => {
@@ -66,7 +66,12 @@ export const UpdateAgentView: FC = () => {
 
       <FormCard>
         <Card.Body>
-          <WithLoadingOverlay isLoading={isLoadingAgent} containerHasRoundedCorners containerBorderRadius='6px'>
+          <WithLoadingOverlay
+            isLoading={isLoadingAgent || isFetching}
+            isInitialLoad={isLoadingAgent && isFetching}
+            containerHasRoundedCorners
+            containerBorderRadius='6px'
+          >
             <StyledFormWrapper>
               <AgentDetailForm
                 defaultValues={agent}

--- a/src/features/user-dashboard/pages/UpdateUserView.tsx
+++ b/src/features/user-dashboard/pages/UpdateUserView.tsx
@@ -20,7 +20,7 @@ export const UpdateUserView: FC = () => {
   const navigate = useNavigate();
   const { userHasPermission } = useRbac();
   const [updateUser] = useUpdateUserMutation();
-  const { data: user, isLoading: isLoadingUser, error: getUserError } = useGetUserByIdQuery(Number(id));
+  const { data: user, isLoading: isLoadingUser, isFetching, error: getUserError } = useGetUserByIdQuery(Number(id));
   const roles = Object.values(Role);
 
   const availableRoles = roles.filter(role => userHasPermission({ permission: 'role:read', data: role }));
@@ -65,7 +65,12 @@ export const UpdateUserView: FC = () => {
 
       <FormCard>
         <FormCard.Body>
-          <WithLoadingOverlay isLoading={isLoadingUser} containerHasRoundedCorners containerBorderRadius='6px'>
+          <WithLoadingOverlay
+            isLoading={isLoadingUser || isFetching}
+            isInitialLoad={isLoadingUser && isFetching}
+            containerHasRoundedCorners
+            containerBorderRadius='6px'
+          >
             <StyledFormWrapper>
               <UserDetailForm
                 availableRoles={availableRoles}

--- a/src/features/user-dashboard/pages/UserListView.tsx
+++ b/src/features/user-dashboard/pages/UserListView.tsx
@@ -1,5 +1,5 @@
 import { useGetUsersQuery } from 'common/api/userApi';
-import { NoContent, PageHeader, TableCard } from 'common/components/Common';
+import { PageHeader, TableCard } from 'common/components/Common';
 import { DataTable } from 'common/components/DataTable';
 import { DataTableFilters, FilterInfo } from 'common/components/DataTable/DataTableFilters';
 import { WithLoadingOverlay } from 'common/components/LoadingSpinner';
@@ -106,30 +106,30 @@ export const UserListView: FC = () => {
       />
       <TableCard>
         <TableCard.Body>
-          <WithLoadingOverlay isLoading={isPageLoading} containerHasRoundedCorners containerBorderRadius='6px'>
-            {data?.meta ? (
-              <DataTable<UserTableItem>
-                columns={columns}
-                data={tableData}
-                onRowClick={item => navigate(`/users/update-user/${item.id}`)}
-                pagination={{
-                  basePage: 1,
-                  page,
-                  pageSize,
-                  count: data?.meta.count || 0,
-                  pageCount: data?.meta.pageCount || 0,
-                  pageSizeOptions: [5, 10, 25, 50, 100],
-                  onPageChange: getPage,
-                  onPageSizeChange: changePageSize,
-                }}
-                sorting={{
-                  onSortByChange: changeSortBy,
-                }}
-                isLoading={isFetching}
-              />
-            ) : (
-              <NoContent />
-            )}
+          <WithLoadingOverlay
+            isLoading={isPageLoading || isFetching}
+            isInitialLoad={isPageLoading && isFetching}
+            containerHasRoundedCorners
+            containerBorderRadius='6px'
+          >
+            <DataTable<UserTableItem>
+              columns={columns}
+              data={tableData}
+              onRowClick={item => navigate(`/users/update-user/${item.id}`)}
+              pagination={{
+                basePage: 1,
+                page,
+                pageSize,
+                count: data?.meta.count || 0,
+                pageCount: data?.meta.pageCount || 0,
+                pageSizeOptions: [5, 10, 25, 50, 100],
+                onPageChange: getPage,
+                onPageSizeChange: changePageSize,
+              }}
+              sorting={{
+                onSortByChange: changeSortBy,
+              }}
+            />
           </WithLoadingOverlay>
         </TableCard.Body>
       </TableCard>


### PR DESCRIPTION
## Changes
1. Changes the WithLoadingOverlay so that the children aren't rendered during the initial load. During the initial load of the data, the NoContent component will be shown under the spinner. For reference, the NoContent component is being used as a skeleton component. We can replace this usage with an actual skeleton component via a separate ticket in the future.
2. The WithLoadingComponent now requires a boolean isInitialLoad prop to be passed in. This is used to support the above functionality.
3. Removed the WithLoadingComponent from the DataTable. I found that it wasn't necessary since the views that made use of the DataTable already enclosed it within the WithLoadingOverlay component.
4. Refactored AgentListView so that the NoContent component wasn't used unnecessarily. Also, deleted the renderDataTableOrNoAgentsView method.

## Purpose
Agent and User update forms will now be pre-populated with data when the user navigates to the update view.

## Testing
1. Pull in the changes to your local copy of this branch
2. Create an agent and then navigate to the seeded user and the agent that you created

## Screenshots

https://user-images.githubusercontent.com/2876874/161635645-c5ed8370-f352-4778-a982-a0cb8cf51594.mov
