### PR TITLE
Fix: links in sidenav should be highlighted when active

### DIFF
--- a/src/features/navbar/components/CustomNavLink.tsx
+++ b/src/features/navbar/components/CustomNavLink.tsx
@@ -1,9 +1,9 @@
 import { IconName } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { FC } from 'react';
-import { NavItem, NavLinkProps } from 'react-bootstrap';
-import { NavLink } from 'react-router-dom';
-import styled, { css } from 'styled-components';
+import { NavItem } from 'react-bootstrap';
+import { NavLink, NavLinkProps } from 'react-router-dom';
+import styled from 'styled-components';
 import { NavLinkConfig } from '../hooks/useNavLinks';
 
 type Props = {
@@ -35,16 +35,14 @@ const NavLinkStyles = styled(NavLink)<NavLinkProps>`
     color: ${props => props.theme.buttons.backgroundColor};
   }
 
-  ${props =>
-    props.active &&
-    css`
-      background: ${props => props.theme.buttons.backgroundColor};
-      color: white;
-    `}
+  &.active {
+    background-color: ${props => props.theme.buttons.backgroundColor};
+    color: white;
+  }
 `;
 
 export const CustomNavLink: FC<Props> = ({ link }) => (
-  <NavLinkStyles to={link.path}>
+  <NavLinkStyles to={link.path} className={({ isActive }) => (isActive ? 'active' : '')}>
     <div>
       <FontAwesomeIcon icon={link.icon} />
       <span>{link.label}</span>


### PR DESCRIPTION
## Changes
1. Fix `NavLinkProps` import to be from `react-router-dom` instead of `react-bootstrap`
2. Pass a function to `NavLinkStyles` className prop that can use the `isActive` state to set the correct active CSS class.

## Purpose
There should be clear UI indication as to which nav link the user is currently on.

## Learning
The `NavLink` component from React Router v6 can take a function for the `className` which receives the `isActive` prop as an argument. The `isActive` prop can then be used to set an appropriate CSS class name. This article was helpful in showing how to do this https://www.kindacode.com/article/react-router-how-to-highlight-active-link/.

## Testing
1. Pull in the changes to your local copy of this branch and `yarn start` application.
2. Click the links in the sidenav and ensure that the selected link gets highlighted with a blue background

## Screenshots
https://user-images.githubusercontent.com/40707951/160705084-b1ff102c-3939-41fe-8b7a-4f1ecd74abdd.mp4
