### PR TITLE
Refactors s3 resource creation syntax that is needed for 4.8.0 terraform version ( for m1 chips)

### DIFF
--- a/terraform/cloudfront/variables.tf
+++ b/terraform/cloudfront/variables.tf
@@ -2,16 +2,26 @@ variable "assume_role_arn" {
   description = "Assume Role ARN"
 }
 
+variable "environment" {
+  description = "This value will be used to tag the resources created with the environment (staging | production | dev)"
+  default     = "staging"
+}
+
 variable "profile" {
   description = "Name of your profile inside ~/.aws/credentials"
   default     = "shift3"
 }
 
-variable "region" {
-  default     = "us-west-2"
-  description = "Defines where your app should be deployed"
-}
-
 variable "web_domain_name" {
   description = "Domain name for the s3 bucket"
+}
+
+variable "secure_response_headers_id"{
+  description = "Default security header policy ID (shift3 account)"
+  default = "b52c8245-8965-4882-a446-8773a50b46ab"
+}
+
+variable "route53_zone" {
+  description = "Zone for Route53"
+  default = "shift3sandbox.com."
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "2.58"
+  version = "4.8.0"
   profile = "${var.profile}"
   region  = "${var.region}"
 
@@ -19,6 +19,6 @@ terraform {
 
 module "cloudfront" {
   source          = "../cloudfront"
-  assume_role_arn = var.assume_role_arn
   web_domain_name = var.web_domain_name
+  assume_role_arn = var.assume_role_arn
 }


### PR DESCRIPTION
## Changes
1. Upgrades 4.8.0 terraform version so that new developers can use terraform with m1 chips
2. Fixes s3 resource logic creation inside CloudFront directory

## Purpose
New developers are experiencing issues with their new m1 chip during the onboarding process. One of the roadblocks is that in order for m1 chips to be usable with terraform, you must upgrade the terraform version. Upgrading, however, requires s3 resource logic creation syntax to be changed. 

I left the source inside the staging directory to be sourced as a directory path rather than a git source. This is because we have a conflicting issue with assume role and SSO (with new developers getting onboarded using SSO) and by leaving it as a directory path, new developers have full control of modifying(deleting) any instance of assume role that causes the error. 


## Testing
1. Clone this branch, then cd into terraform/staging directory
2. Create a test.tfvars and have a variable named web_domain_name and give it a string value
3. run terraform init inside staging directory
4. run terraform plan -var-file=test.tfvars
