### PR TITLE
chore(codeowners): add Elizabeth as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @DropsOfSerenity @AramayisO @joshwingreene
+* @DropsOfSerenity @AramayisO @joshwingreene @fluturecode


### PR DESCRIPTION
## Changes
1. Added Elizabeth as a code owner

## Purpose
Elizabeth is now back on the project and should automatically be added as a reviewer on an PR opened on the project.

