### PR TITLE
Removed `moment` from project

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "dotenv": "^16.0.0",
     "history": "^5.3.0",
     "http-status-codes": "^2.1.4",
-    "moment": "^2.29.3",
     "react": "^18.1.0",
     "react-bootstrap": "^2.3.1",
     "react-dom": "^18.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6727,11 +6727,6 @@ mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-moment@^2.29.3:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
-
 mri@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"


### PR DESCRIPTION
## Changes
1. Ran `Depcheck` (https://github.com/depcheck/depcheck#readme) .
2. Removed `moment` package from project.

## Purpose
To remove the moment package, since it is not being used in the project.

## Learning
Runnign `depcheck` showed 3 packages not being used, however we are using Dotenv and Sentry, so only removing Moment was necessary.
![Screen Shot 2022-05-09 at 5 52 51 PM](https://user-images.githubusercontent.com/59614789/167691959-f5030489-f560-46a7-81ae-4d686de13a8a.png)

## Testing
1. Pull in the changes to your local copy of this branch and run `yarn start`.
2. Make sure the project runs without any errors.
