### PR TITLE
Fix bug where PrivateRoute was not working correctly.

### DIFF
--- a/src/common/services/notification.tsx
+++ b/src/common/services/notification.tsx
@@ -10,5 +10,6 @@ export const showSuccessMessage = (message: string): void => {
 export const showErrorMessage = (message: string): void => {
   toast.error(message, {
     icon: <ErrorNotificationIcon />,
+    toastId: message,
   });
 };

--- a/src/features/auth/components/RequireAuth.tsx
+++ b/src/features/auth/components/RequireAuth.tsx
@@ -21,7 +21,7 @@ export const RequireAuth: FC<PropsWithChildren<RequireAuthProps>> = ({ children,
 
   if (allowedRoles.length !== 0 && !allowedRoles.includes(auth.user.role)) {
     notificationService.showErrorMessage('Not authorized to view the requested page.');
-    <Navigate to='/agents' />;
+    return <Navigate to='/agents' replace />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
* Protected routes were not working correctly.
* Notifications were also displaying multiple times, to get around this we use the notification message as the toastId so they are not duplicated.

Closes #580 