### PR TITLE
Fix bug where the "is" operation for both list views was case-sensitive

### DIFF
--- a/src/common/api/queryParamsBuilder.ts
+++ b/src/common/api/queryParamsBuilder.ts
@@ -29,8 +29,7 @@ export class QueryParamsBuilder {
 
   public setFilterParam(filters: Filter[]): QueryParamsBuilder {
     filters.forEach(f => {
-      if (f.op !== 'eq') this.setParam(`${f.attr}__${f.op}`, f.value);
-      else this.setParam(f.attr, f.value);
+      this.setParam(`${f.attr}__${f.op}`, f.value);
     });
     return this;
   }

--- a/src/common/models/filtering.ts
+++ b/src/common/models/filtering.ts
@@ -1,5 +1,5 @@
 export type FilterOp =
-  | 'eq'
+  | 'iexact'
   | 'neq'
   | 'contains'
   | 'icontains'

--- a/src/features/agent-dashboard/pages/AgentListView.tsx
+++ b/src/features/agent-dashboard/pages/AgentListView.tsx
@@ -45,7 +45,7 @@ export const AgentListView: FC = () => {
         attributeLabel: 'Name',
         operationOptions: [
           {
-            operation: 'eq',
+            operation: 'iexact',
             operationLabel: 'is',
           },
           {

--- a/src/features/user-dashboard/pages/UserListView.tsx
+++ b/src/features/user-dashboard/pages/UserListView.tsx
@@ -42,7 +42,7 @@ export const UserListView: FC = () => {
         attributeLabel: 'First Name',
         operationOptions: [
           {
-            operation: 'eq',
+            operation: 'iexact',
             operationLabel: 'is',
           },
           {
@@ -64,7 +64,7 @@ export const UserListView: FC = () => {
         attributeLabel: 'Last Name',
         operationOptions: [
           {
-            operation: 'eq',
+            operation: 'iexact',
             operationLabel: 'is',
           },
           {


### PR DESCRIPTION
## Changes
- Changed 'eq' to 'iexact' in `FilterOp`
- Made the iexact / is operation behave the same as the other operations in `queryParamsBuilder.ts`
- Updated both list views accordingly

## Purpose
- This makes the `is` operation for both list views case-insensitive.

## Testing
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo under the branch with the same name
2. Create two agents and a user
3. Test the `is` operation for both the Agent and User List Views

### Closes #576 
