### PR TITLE
Fixes the bug that was causing the startswith and endswith filters to be case-senstive

### DIFF
--- a/src/common/models/filtering.ts
+++ b/src/common/models/filtering.ts
@@ -7,8 +7,8 @@ export type FilterOp =
   | 'lt'
   | 'gte'
   | 'lte'
-  | 'startswith'
-  | 'endswith';
+  | 'istartswith'
+  | 'iendswith';
 
 export type Filter = {
   attr: string;

--- a/src/features/agent-dashboard/pages/AgentListView.tsx
+++ b/src/features/agent-dashboard/pages/AgentListView.tsx
@@ -53,11 +53,11 @@ export const AgentListView: FC = () => {
             operationLabel: 'contains',
           },
           {
-            operation: 'startswith',
+            operation: 'istartswith',
             operationLabel: 'starts with',
           },
           {
-            operation: 'endswith',
+            operation: 'iendswith',
             operationLabel: 'ends with',
           },
         ],

--- a/src/features/user-dashboard/pages/UserListView.tsx
+++ b/src/features/user-dashboard/pages/UserListView.tsx
@@ -50,11 +50,11 @@ export const UserListView: FC = () => {
             operationLabel: 'contains',
           },
           {
-            operation: 'startswith',
+            operation: 'istartswith',
             operationLabel: 'starts with',
           },
           {
-            operation: 'endswith',
+            operation: 'iendswith',
             operationLabel: 'ends with',
           },
         ],
@@ -72,11 +72,11 @@ export const UserListView: FC = () => {
             operationLabel: 'contains',
           },
           {
-            operation: 'startswith',
+            operation: 'istartswith',
             operationLabel: 'starts with',
           },
           {
-            operation: 'endswith',
+            operation: 'iendswith',
             operationLabel: 'ends with',
           },
         ],


### PR DESCRIPTION
## Changes
- The startswith and endswith filters for both the Agent and User list views are no longer case-sensitive.

## Note
- All of the filters for the user and agent list views are now case-insensitive.

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo under the branch with the same name
2. Create an agent
3. Test the `starts with` and `ends with` operations for both the Agent and User List Views

### Closes #576 
