### PR TITLE
Fixes the pagination bug that was not allowing all of the pages to be accessed when the page size was changed

### DIFF
--- a/src/common/hooks/usePSFQuery.ts
+++ b/src/common/hooks/usePSFQuery.ts
@@ -138,13 +138,6 @@ export const usePSFQuery = <ResultType>(
         const { pageCount } = state;
         const lastPage = basePage + pageCount - 1;
 
-        console.log('setPage');
-        console.log('--------');
-        console.log('config:', config);
-        console.log('state:', state);
-        console.log('pageCount:', pageCount);
-        console.log('lastPage:', lastPage);
-
         if (basePage <= page && page <= lastPage) {
           const hasPreviousPage = basePage < page;
           const hasNextPage = page < lastPage;
@@ -157,13 +150,6 @@ export const usePSFQuery = <ResultType>(
       case 'pagination/setPageSize': {
         const { size } = action.payload;
         const { minPageSize, maxPageSize } = config;
-
-        console.log('setPageSize');
-        console.log('-----------');
-        console.log('config:', config);
-        console.log('size:', size);
-        console.log('minPageSize:', minPageSize);
-        console.log('maxPageSize:', maxPageSize);
 
         if (minPageSize <= size && size <= maxPageSize) {
           const pageSize = size;
@@ -213,14 +199,11 @@ export const usePSFQuery = <ResultType>(
         const { data } = action.payload;
         let newState = { ...state };
 
-        console.log('*** dataUpdated ***');
-
         // If the data is paginated, we need to update the count and pageCount in case the values
         // have changed (e.g. a filter was applied and the result set is smaller). This also
         // requires re-calculating if there are previous and next pages.
         if (isPaginatedResult(data)) {
           const { count, pageCount } = data.meta;
-          console.log('meta:', data.meta);
           const { basePage } = config;
           const { page } = state;
           const lastPage = basePage + pageCount - 1;


### PR DESCRIPTION
## Changes
- Updates the pageCount when the page size is changed.

## Purpose
- The pageCount was only being updated when the data was initially fetched and when the data was changed on the backend. Because of this, the pageCount would never be changed when the user changed the page size. This PR resolves this issue. 

## Approach
1. Calculates the new pageCount in the setPageSize action
2. Updates the state with this updated value

## Learning
- I learned more about how the usePSFQuery hook worked.

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo. You can use either the main or develop branch.
2. Create 21 agents or 20 users

### Closes #578 
