### PR TITLE
Word wrap in table cells

### DIFF
--- a/src/common/styles/card.tsx
+++ b/src/common/styles/card.tsx
@@ -53,6 +53,7 @@ export const TableCard = styled(Card)`
         padding: 0.5rem;
         display: flex;
         align-items: center;
+        word-break: break-all;
 
         &:last-of-type {
           justify-content: flex-end;


### PR DESCRIPTION
Ensures that long lines in table are wrapped, even if the word contains no spaces.

![image](https://user-images.githubusercontent.com/2287977/180049443-138ac81b-89c2-4a21-aacc-20f14c3d164e.png)

This Closes #607 