### PR TITLE
Make all columns in user table sortable.

### DIFF
--- a/src/features/user-dashboard/hooks/useUserTableData.tsx
+++ b/src/features/user-dashboard/hooks/useUserTableData.tsx
@@ -125,7 +125,6 @@ export const useUserTableData: UseUserTableData = (users = []) => {
             {role}
           </SubtleBadge>
         ),
-        disableSortBy: true,
       },
       {
         accessor: 'activatedAt',
@@ -143,7 +142,6 @@ export const useUserTableData: UseUserTableData = (users = []) => {
             )}
           </>
         ),
-        disableSortBy: true,
       },
       {
         accessor: 'actions',


### PR DESCRIPTION
There is no reason why all columns in the user table should not be sortable, so this PR makes them all sortable.

![image](https://user-images.githubusercontent.com/2287977/180050263-c8a189d7-e061-4471-8990-cbda8cc042fb.png)

Closes #603 
