### PR TITLE
Fixed `spanish` language dropdown

### DIFF
--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -16,7 +16,7 @@ export const languages = [
     translation: translationEN,
   },
   {
-    label: 'Spanish',
+    label: 'Español',
     shortcode: 'es',
     translation: translationES,
   },


### PR DESCRIPTION
References #615 

## Changes
1. Renamed Spanish dropdown to `Español`
 
## Purpose
It's best practice to have the language displayed in it's native language.

### Closes #615 
