### PR TITLE
Fixes the bug that was causing search to stop working when you weren't on the first page of results

### DIFF
--- a/src/common/hooks/usePSFQuery.ts
+++ b/src/common/hooks/usePSFQuery.ts
@@ -198,7 +198,8 @@ export const usePSFQuery = <ResultType>(
 
       case 'addSearchText': {
         const { payload } = action;
-        return { ...state, searchText: payload.data };
+        const page = state.searchText !== payload.data ? 1 : state.page;
+        return { ...state, searchText: payload.data, page };
       }
 
       case 'all/dataUpdated': {


### PR DESCRIPTION
## Changes
The page value will now be reset when the searchText is changed by the user.

## Purpose
This resolves the bug that was causing the search feature to stop working when you tried to search when you weren't on the first page of results.

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the develop branch of the dj_starter_demo repo.
2. Create 12 agents or 12 users.
3. Go to the second page and try to use the search bar.

## Screenshots

![first page](https://user-images.githubusercontent.com/2876874/182979170-b687b311-a12c-4829-a16f-1d0ab114c14d.png)

![second page and while searching](https://user-images.githubusercontent.com/2876874/182979196-530b4ad0-efa1-4861-b7d0-70e80022e524.png)

### Closes #616 
