### PR TITLE
Fix translation on UpdateUserProfilePage

### DIFF
--- a/src/features/user-profile/pages/UpdateUserProfilePage.tsx
+++ b/src/features/user-profile/pages/UpdateUserProfilePage.tsx
@@ -216,8 +216,11 @@ export const UpdateUserProfilePage: FC = () => {
                   <div>
                     <p data-testid='updateUserExistingEmailChangeInfoContent'>
                       <Trans i18nKey='userProfile.changeEmailDescription'>
-                        You requested an email change. A verification email has been sent to <b>{user.newEmail}</b>. To
-                        confirm your new email, please follow the directions in the verification email.
+                        You requested an email change. A verification email has been sent to{' '}
+                        <strong>
+                          <>{{ email: user.newEmail }}</>
+                        </strong>
+                        . To confirm your new email, please follow the directions in the verification email.
                       </Trans>
                     </p>
                     <Button

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -35,7 +35,7 @@
     "generalSubheading": "This information will be used to identify you in our system",
     "email": "Email Address",
     "emailDescription": "Your email address on file will be used to communicate with you. Changing your email requires you to confirm your new email address.",
-    "changeEmailDescription": "You requested an email change. A verification email has been sent to <1>{user.newEmail}</1>. To confirm your new email, please follow the directions in the verification email.",
+    "changeEmailDescription": "You requested an email change. A verification email has been sent to <1>{{ email }}</1>. To confirm your new email, please follow the directions in the verification email.",
     "resendEmail": "Resend Verification Email",
     "photo": "Photo",
     "photoDescription": "This is the photo of you that other users in the system will be able to see.",

--- a/src/i18n/es/translation.json
+++ b/src/i18n/es/translation.json
@@ -35,7 +35,7 @@
     "generalSubheading": "Esta información se utilizará para identificarlo en nuestro sistema.",
     "email": "Dirección de correo electrónico",
     "emailDescription": "Su dirección de correo electrónico registrada se utilizará para comunicarnos con usted. Cambiar su correo electrónico requiere que confirme su nueva dirección de correo electrónico.",
-    "changeEmailDescription": "Usted solicitó un cambio de correo electrónico. Se ha enviado un correo electrónico de verificación a <1>{user.newEmail}</1>. Para confirmar su nuevo correo electrónico, siga las instrucciones en el correo electrónico de verificación.",
+    "changeEmailDescription": "Usted solicitó un cambio de correo electrónico. Se ha enviado un correo electrónico de verificación a <1>{{ email }}</1>. Para confirmar su nuevo correo electrónico, siga las instrucciones en el correo electrónico de verificación.",
     "resendEmail": "Reenviar correo electrónico de verificación",
     "photo": "Photo",
     "photoDescription": "Esta es la foto tuya que otros usuarios del sistema podrán ver.",


### PR DESCRIPTION
Fixes a bug on the update profile page, where interpolation was not working properly, due to being nested in a `<Trans>` component

## Learning
https://react.i18next.com/latest/trans-component#interpolation

