### PR TITLE
Pagination results will now be updated in the correct manner when searching/filtering is being used and when you aren't on the first page of results

### DIFF
--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -174,13 +174,13 @@ export const DataTable = <D extends Record<string, unknown>>({
       {/* If the usePagination plugin is enabled, render a paginator to allow users to page through the data. */}
       {paginationEnabled && (
         <Paginator
-          page={pageIndex + pagination.basePage}
+          page={pagination.page} // pageIndex + pagination.basePage
           pageSize={pageSize}
           count={pagination.count}
           pageCount={pageCount}
           pageSizeOptions={pagination.pageSizeOptions}
-          hasPreviousPage={canPreviousPage}
-          hasNextPage={canNextPage}
+          hasPreviousPage={pagination.page > 1} // canPreviousPage
+          hasNextPage={pagination.page < pagination.pageCount} // canNextPage
           onPreviousPageClick={previousPage}
           onNextPageClick={nextPage}
           onPageSizeChange={setPageSize}

--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -67,6 +67,19 @@ export const DataTable = <D extends Record<string, unknown>>({
       columns,
       data,
       initialState,
+      stateReducer: (newState, action) => {
+        console.log('stateReducer - newState -', newState);
+
+        switch (action.type) {
+          case 'filter or search was used':
+            return {
+              ...newState,
+              pageIndex: 0,
+            };
+          default:
+            return newState;
+        }
+      },
       ...extraTableOptions,
     },
     useFlexLayout,
@@ -89,6 +102,7 @@ export const DataTable = <D extends Record<string, unknown>>({
     nextPage,
     previousPage,
     setPageSize,
+    dispatch,
     // Instance state
     state: { pageIndex, pageSize, sortBy },
   } = tableInstance;
@@ -114,6 +128,8 @@ export const DataTable = <D extends Record<string, unknown>>({
   // any time there is a change to page index or page size.
   useEffect(
     () => {
+      console.log('useEffect - pagination -', pagination);
+      console.log('useEffect - tableInstance -', tableInstance);
       if (paginationEnabled) {
         pagination.onPageChange(pageIndex + pagination.basePage);
         pagination.onPageSizeChange(pageSize);
@@ -122,6 +138,21 @@ export const DataTable = <D extends Record<string, unknown>>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [pageIndex, pageSize, paginationEnabled, pagination?.onPageChange, pagination?.onPageSizeChange],
   );
+
+  useEffect(() => {
+    console.log('page from PSF or table changed');
+
+    console.log('pagination - page -', pagination?.page);
+
+    console.log('tableInstance - pageIndex -', pageIndex);
+
+    if (pagination) {
+      if (pagination.page <= pageIndex) {
+        console.log('search or filter was used');
+        dispatch({ type: 'filter or search was used' });
+      }
+    }
+  }, [pagination?.page]);
 
   return (
     <div className='d-flex flex-column'>
@@ -174,13 +205,13 @@ export const DataTable = <D extends Record<string, unknown>>({
       {/* If the usePagination plugin is enabled, render a paginator to allow users to page through the data. */}
       {paginationEnabled && (
         <Paginator
-          page={pagination.page} // pageIndex + pagination.basePage
+          page={pageIndex + pagination.basePage} // pageIndex + pagination.basePage // pagination.page
           pageSize={pageSize}
           count={pagination.count}
           pageCount={pageCount}
           pageSizeOptions={pagination.pageSizeOptions}
-          hasPreviousPage={pagination.page > 1} // canPreviousPage
-          hasNextPage={pagination.page < pagination.pageCount} // canNextPage
+          hasPreviousPage={canPreviousPage} // canPreviousPage // pagination.page > 1
+          hasNextPage={canNextPage} // canNextPage // pagination.page < pagination.pageCount
           onPreviousPageClick={previousPage}
           onNextPageClick={nextPage}
           onPageSizeChange={setPageSize}

--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -199,13 +199,13 @@ export const DataTable = <D extends Record<string, unknown>>({
       {/* If the usePagination plugin is enabled, render a paginator to allow users to page through the data. */}
       {paginationEnabled && (
         <Paginator
-          page={pageIndex + pagination.basePage} // pageIndex + pagination.basePage // pagination.page
+          page={pageIndex + pagination.basePage}
           pageSize={pageSize}
           count={pagination.count}
           pageCount={pageCount}
           pageSizeOptions={pagination.pageSizeOptions}
-          hasPreviousPage={canPreviousPage} // canPreviousPage // pagination.page > 1
-          hasNextPage={canNextPage} // canNextPage // pagination.page < pagination.pageCount
+          hasPreviousPage={canPreviousPage}
+          hasNextPage={canNextPage}
           onPreviousPageClick={previousPage}
           onNextPageClick={nextPage}
           onPageSizeChange={setPageSize}

--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -68,8 +68,6 @@ export const DataTable = <D extends Record<string, unknown>>({
       data,
       initialState,
       stateReducer: (newState, action) => {
-        console.log('stateReducer - newState -', newState);
-
         switch (action.type) {
           case 'filter or search was used':
             return {
@@ -128,8 +126,6 @@ export const DataTable = <D extends Record<string, unknown>>({
   // any time there is a change to page index or page size.
   useEffect(
     () => {
-      console.log('useEffect - pagination -', pagination);
-      console.log('useEffect - tableInstance -', tableInstance);
       if (paginationEnabled) {
         pagination.onPageChange(pageIndex + pagination.basePage);
         pagination.onPageSizeChange(pageSize);
@@ -139,19 +135,17 @@ export const DataTable = <D extends Record<string, unknown>>({
     [pageIndex, pageSize, paginationEnabled, pagination?.onPageChange, pagination?.onPageSizeChange],
   );
 
+  // When switching between pages via the Paginator, the table's pageIndex will always be 1 less than pagination.page.
+  // However, if the user uses search or a filter, then pagination.page will be less than or equal to the pageIndex.
+  // In this case, we need to reset the table's pageIndex to 0. This will cause the pagination numbering and next/previous
+  // buttons to be updated and the result will be consistent with the current data set.
   useEffect(() => {
-    console.log('page from PSF or table changed');
-
-    console.log('pagination - page -', pagination?.page);
-
-    console.log('tableInstance - pageIndex -', pageIndex);
-
     if (pagination) {
       if (pagination.page <= pageIndex) {
-        console.log('search or filter was used');
         dispatch({ type: 'filter or search was used' });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pagination?.page]);
 
   return (

--- a/src/common/components/DataTable/DataTableSearchAndFilters.tsx
+++ b/src/common/components/DataTable/DataTableSearchAndFilters.tsx
@@ -103,7 +103,7 @@ export const DataTableSearchAndFilters: FC<DataTableSearchAndFilterProps> = ({
     }, 200);
 
     return () => clearTimeout(delayDebounceFn);
-  });
+  }, [searchValue, onSetSearchText]);
 
   return (
     <>


### PR DESCRIPTION
## Changes
- Dispatches an action to the table's stateReducer when the user either uses search, a filter, or both. This action will reset the table's pageIndex to 0.

## Purpose / Approach
- When switching between pages via the Paginator, the table's pageIndex will always be 1 less than pagination.page.
However, if the user uses search or a filter, then pagination.page will be less than or equal to the pageIndex.
In this case, we need to reset the table's pageIndex to 0. This will cause the pagination numbering and next/previous
buttons to be updated and the result will be consistent with the current data set.

## Learning
- I reviewed the react-table's documentation. I specifically reviewed its [useTable hook](https://react-table-v7.tanstack.com/docs/api/useTable#table-options).

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo. You can use either the main or develop branch.
2. Create 21 agents or 20 users

## Screenshots

https://user-images.githubusercontent.com/2876874/188032415-eb9383f7-83a4-4f44-99af-63ff89230ac3.mov

### Closes #618