### PR TITLE
A few style fixes. 

### DIFF
--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -79,7 +79,7 @@ export const GlobalStyle = createGlobalStyle<{ theme: typeof dark }>`
         color: ${({ theme }) => theme.pages.p} !important;
     }
 
-    .btn-primary {
+    .btn.btn-primary {
         background-color: ${({ theme }) => theme.buttons.primaryBackgroundColor};
         border-color: ${({ theme }) => theme.buttons.primaryBorderColor};
         color: ${({ theme }) => theme.buttons.primaryTextColor};
@@ -91,7 +91,7 @@ export const GlobalStyle = createGlobalStyle<{ theme: typeof dark }>`
         }
     }
 
-    .btn-default {
+    .btn.btn-default {
         background-color: ${({ theme }) => theme.buttons.defaultBackgroundColor};
         border-color: ${({ theme }) => theme.buttons.defaultBorderColor};
         color: ${({ theme }) => theme.buttons.defaultTextColor};

--- a/src/common/styles/page.tsx
+++ b/src/common/styles/page.tsx
@@ -10,9 +10,7 @@ export const PageWrapper = styled.div`
 `;
 
 export const SmallContainer = styled(Container)`
-  max-width: 540px;
-
-  @media (min-width: 768px) {
+  @media (min-width: 1200px) {
     max-width: 960px;
   }
 `;
@@ -33,6 +31,8 @@ export const PageHeader = styled.div`
   justify-content: space-between;
   flex-wrap: wrap;
   align-content: space-between;
+  border-bottom: 1px solid ${props => props.theme.nav.borderColor};
+  margin-bottom: 1.25rem;
 
   & > * {
     margin-bottom: 1rem;


### PR DESCRIPTION
* `btn` selector became more specific in the latest `bootstrap.css` so
  global styles needed to target a more specific selector to override.
* `PageHeader` now has a bottom border to separate it from the content.
* `SmallContainer` fixed to only override width: 1200px and above so
  that it aligns properly on all smaller screen sizes.

![image](https://user-images.githubusercontent.com/2287977/193699141-217d1e84-3387-4643-8b58-e15dc49ede03.png)
