### PR TITLE
Fixes the filter dropdown border blending issue

### DIFF
--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -39,9 +39,7 @@ const FilterMenu = styled(Card)`
   border-radius: ${props => props.theme.borderRadius};
   background-color: ${props => props.theme.card.backgroundColor};
   box-shadow: ${props => props.theme.boxShadow} !important;
-  border-width: 0.063em !important;
-  border-color: rgba(255, 255, 255, 0.1) !important;
-  border-style: solid !important;
+  border: ${props => props.theme.card.border} !important;
 
   & ul {
     list-style: none;

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -39,6 +39,9 @@ const FilterMenu = styled(Card)`
   border-radius: ${props => props.theme.borderRadius};
   background-color: ${props => props.theme.card.backgroundColor};
   box-shadow: ${props => props.theme.boxShadow} !important;
+  border-width: 0.063em !important;
+  border-color: rgba(255, 255, 255, 0.1) !important;
+  border-style: solid !important;
 
   & ul {
     list-style: none;

--- a/src/themes/colors.ts
+++ b/src/themes/colors.ts
@@ -2,6 +2,7 @@ export const colors = {
   white: '#FFFFFF',
   black: '#000000',
   dangerRed: '#DC2626',
+  darkGray: '#ffffff1a',
 
   neutral50: '#f8fafc',
   neutral100: '#f1f5f9',

--- a/src/themes/colors.ts
+++ b/src/themes/colors.ts
@@ -2,7 +2,6 @@ export const colors = {
   white: '#FFFFFF',
   black: '#000000',
   dangerRed: '#DC2626',
-  darkGray: '#ffffff1a',
 
   neutral50: '#f8fafc',
   neutral100: '#f1f5f9',

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -14,7 +14,7 @@ export default {
   card: {
     backgroundColor: colors.neutral800,
     textColor: colors.white,
-    border: `0.063em solid ${  colors.darkGray}`,
+    border: `1px solid ${colors.neutral700}`,
   },
 
   nav: {
@@ -34,7 +34,7 @@ export default {
     },
 
     horizontal: {
-      backgroundColor: colors.darkGray,
+      backgroundColor: 'rgba(255, 255, 255, 0.10)',
     },
     vertical: {
       backgroundColor: colors.neutral900,

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -14,6 +14,7 @@ export default {
   card: {
     backgroundColor: colors.neutral800,
     textColor: colors.white,
+    border: '0.063em solid rgba(255, 255, 255, 0.1)',
   },
 
   nav: {

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -14,7 +14,7 @@ export default {
   card: {
     backgroundColor: colors.neutral800,
     textColor: colors.white,
-    border: '0.063em solid rgba(255, 255, 255, 0.1)',
+    border: `0.063em solid ${  colors.darkGray}`,
   },
 
   nav: {
@@ -34,7 +34,7 @@ export default {
     },
 
     horizontal: {
-      backgroundColor: 'rgba(255, 255, 255, 0.10)',
+      backgroundColor: colors.darkGray,
     },
     vertical: {
       backgroundColor: colors.neutral900,

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -14,6 +14,7 @@ export default {
   card: {
     backgroundColor: colors.white,
     textColor: colors.black,
+    border: 'none',
   },
 
   nav: {


### PR DESCRIPTION
## Changes
1. Adds a card border property to the dark and light theme files. For the dark theme, the border color is the same as the nav bar background. For the light theme, the order is set to none (this matches the styling of the card component from React-Bootstrap).
2. Adds a darkGray color to colors.ts. Since the dark gray color of the navbar is now used in two places, it made sense to add it to the colors file.

## Purpose
Fixes the filter dropdown border blending issue

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo.
3. Open the filter menu for both the light and dark menus on either the User or Agent List Views.

## Screenshots

![filter menu fix](https://user-images.githubusercontent.com/2876874/195952769-644b0bb5-a976-45f4-8cc1-0e11f39183bf.png)

Closes #620 