### PR TITLE
Filters can now be de-selected individually

### DIFF
--- a/src/common/components/DataTable/DataTableSearchAndFilters.tsx
+++ b/src/common/components/DataTable/DataTableSearchAndFilters.tsx
@@ -87,7 +87,7 @@ export const DataTableSearchAndFilters: FC<DataTableSearchAndFilterProps> = ({
   };
 
   const removeFilter = (attr: string, op: FilterOp) => {
-    setActiveFilters(activeFilters.filter(filter => filter.attr !== attr));
+    setActiveFilters(activeFilters.filter(filter => !(filter.attr === attr && filter.op === op)));
     onRemoveFilter(attr, op);
   };
 

--- a/src/common/components/DataTable/DataTableSearchAndFilters.tsx
+++ b/src/common/components/DataTable/DataTableSearchAndFilters.tsx
@@ -87,7 +87,7 @@ export const DataTableSearchAndFilters: FC<DataTableSearchAndFilterProps> = ({
   };
 
   const removeFilter = (attr: string, op: FilterOp) => {
-    setActiveFilters(activeFilters.filter(filter => filter.attr !== attr && filter.op !== op));
+    setActiveFilters(activeFilters.filter(filter => filter.attr !== attr));
     onRemoveFilter(attr, op);
   };
 

--- a/src/common/components/DataTable/DataTableSearchAndFilters.tsx
+++ b/src/common/components/DataTable/DataTableSearchAndFilters.tsx
@@ -87,7 +87,7 @@ export const DataTableSearchAndFilters: FC<DataTableSearchAndFilterProps> = ({
   };
 
   const removeFilter = (attr: string, op: FilterOp) => {
-    setActiveFilters(activeFilters.filter(filter => filter.attr !== attr));
+    setActiveFilters(activeFilters.filter(filter => filter.attr !== attr && filter.op !== op));
     onRemoveFilter(attr, op);
   };
 

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -139,9 +139,15 @@ const FilterCategory = styled.div`
 
     svg#clear {
       flex: .5;
-      padding: 0.75rem 0;
+      padding: 0.50rem 0;
+      border-radius: ${props => props.theme.borderRadius};
       display: none;
       cursor: pointer;
+
+      &:hover {
+        background-color: ${props => props.theme.noticeBackgroundColor};
+        color: ${props => props.theme.noticeTextColor};
+      }
 
       &.active {
         display: inline-block;

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -137,20 +137,22 @@ const FilterCategory = styled.div`
     align-items: center;
     justify-content: spaced-between;
 
-    #close {
-      flex: 1;
+    svg#clear {
+      flex: .5;
       padding: 0.75rem 0;
       display: none;
+      cursor: pointer;
 
       &.active {
         display: inline-block;
       }
     }
 
-    #toggle {
+    svg#toggle {
       transition: all 0.15s ease;
-      flex: 1;
+      flex: .5;
       padding: 0.75rem 0;
+      cursor: pointer;
     }
   }
 
@@ -199,7 +201,7 @@ const FilterCategory = styled.div`
     }
 
     #button-container {
-      #toggle {
+      svg#toggle {
         transform: rotateZ(180deg);
       }
     }
@@ -253,6 +255,10 @@ export const FilterDropdown: FC<{
     else setOpenFilter(filter);
   };
 
+  const checkIfActiveFilter = (filter: FilterInfo): string => {
+    return activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : '';
+  } 
+
   return (
     <StyledDropdown className={show ? 'show' : ''} ref={dropdownContainerRef}>
       <FilterMenu>
@@ -267,11 +273,11 @@ export const FilterDropdown: FC<{
           <FilterCategory key={filter.attribute} className={openFilter === filter ? 'open' : ''}>
             <div id='button-container'>
               <div role='button' tabIndex={-1} className='category' onClick={() => toggleCategory(filter)}>
-                <span className={activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : ''}>
+                <span className={checkIfActiveFilter(filter)}>
                   {filter.attributeLabel}
                 </span>
               </div>
-              <FontAwesomeIcon id='close' className={activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : ''} icon='xmark' />
+              <FontAwesomeIcon id='clear' className={checkIfActiveFilter(filter)} icon='xmark' onClick={() => console.log('Remove Filter')} />
               <FontAwesomeIcon id='toggle' icon='chevron-down' onClick={() => toggleCategory(filter)} />
             </div>
 

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -67,11 +67,11 @@ const FilterCategory = styled.div`
     border-bottom: 1px solid ${props => props.theme.buttons.defaultBackgroundColor};
   }
 
-  #action-container {
+  .action-container {
     display: flex;
     align-items: center;
 
-    svg#remove {
+    svg.remove {
       flex: 0.5;
       padding: 0.5rem 0;
       border-radius: ${props => props.theme.borderRadius};
@@ -88,7 +88,7 @@ const FilterCategory = styled.div`
       }
     }
 
-    svg#toggle {
+    svg.toggle {
       transition: all 0.15s ease;
       flex: 0.5;
       padding: 0.75rem 0;
@@ -136,12 +136,12 @@ const FilterCategory = styled.div`
   }
 
   &.open {
-    #action-container > .category {
+    .action-container > .category {
       color: ${props => props.theme.textColor};
     }
 
-    #action-container {
-      svg#toggle {
+    .action-container {
+      svg.toggle {
         transform: rotateZ(180deg);
       }
     }
@@ -195,14 +195,16 @@ export const FilterDropdown: FC<{
     else setOpenFilter(filter);
   };
 
-  const checkIfActiveFilter = (filter: FilterInfo): string => {
-    return activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : '';
+  const isFilterActive = (filter: FilterInfo) => {
+    return activeFilters.find(a => a.attr === filter.attribute);
   };
 
   const handleFilterRemoval = (filter: FilterInfo) => {
-    const filterToRemove = activeFilters.filter(a => a.attr === filter.attribute)[0];
+    const filterToRemove = activeFilters.find(a => a.attr === filter.attribute);
 
-    removeFilter(filterToRemove.attr, filterToRemove.op);
+    if (filterToRemove) {
+      removeFilter(filterToRemove.attr, filterToRemove.op);
+    }
   };
 
   return (
@@ -217,17 +219,16 @@ export const FilterDropdown: FC<{
 
         {filters.map(filter => (
           <FilterCategory key={filter.attribute} className={openFilter === filter ? 'open' : ''}>
-            <div id='action-container'>
+            <div className='action-container'>
               <div role='button' tabIndex={-1} className='category' onClick={() => toggleCategory(filter)}>
-                <span className={checkIfActiveFilter(filter)}>{filter.attributeLabel}</span>
+                <span className={isFilterActive(filter) ? 'active' : ''}>{filter.attributeLabel}</span>
               </div>
               <FontAwesomeIcon
-                id='remove'
-                className={checkIfActiveFilter(filter)}
+                className={`remove ${isFilterActive(filter) ? 'active' : ''}`}
                 icon='xmark'
                 onClick={() => handleFilterRemoval(filter)}
               />
-              <FontAwesomeIcon id='toggle' icon='chevron-down' onClick={() => toggleCategory(filter)} />
+              <FontAwesomeIcon className='toggle' icon='chevron-down' onClick={() => toggleCategory(filter)} />
             </div>
 
             <div className='content'>

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -259,6 +259,12 @@ export const FilterDropdown: FC<{
     return activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : '';
   } 
 
+  const handleFilterRemoval = (filter: FilterInfo) => {
+    const filterToRemove = activeFilters.filter(a => a.attr === filter.attribute)[0];
+
+    removeFilter(filterToRemove.attr, filterToRemove.op);
+  }
+
   return (
     <StyledDropdown className={show ? 'show' : ''} ref={dropdownContainerRef}>
       <FilterMenu>
@@ -277,7 +283,7 @@ export const FilterDropdown: FC<{
                   {filter.attributeLabel}
                 </span>
               </div>
-              <FontAwesomeIcon id='clear' className={checkIfActiveFilter(filter)} icon='xmark' onClick={() => console.log('Remove Filter')} />
+              <FontAwesomeIcon id='clear' className={checkIfActiveFilter(filter)} icon='xmark' onClick={() => handleFilterRemoval(filter)} />
               <FontAwesomeIcon id='toggle' icon='chevron-down' onClick={() => toggleCategory(filter)} />
             </div>
 

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -135,17 +135,22 @@ const FilterCategory = styled.div`
   #button-container {
     display: flex;
     align-items: center;
+    justify-content: spaced-between;
 
     #close {
-      margin-right: 1em;
-      margin-left: 1em;
       flex: 1;
+      padding: 0.75rem 0;
+      display: none;
+
+      &.active {
+        display: inline-block;
+      }
     }
 
     #toggle {
-      margin-right: 1em;
       transition: all 0.15s ease;
       flex: 1;
+      padding: 0.75rem 0;
     }
   }
 
@@ -266,8 +271,8 @@ export const FilterDropdown: FC<{
                   {filter.attributeLabel}
                 </span>
               </div>
-              <FontAwesomeIcon id='close' icon='xmark' />
-              <FontAwesomeIcon id='toggle' icon='chevron-down' />
+              <FontAwesomeIcon id='close' className={activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : ''} icon='xmark' />
+              <FontAwesomeIcon id='toggle' icon='chevron-down' onClick={() => toggleCategory(filter)} />
             </div>
 
             <div className='content'>

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -70,7 +70,6 @@ const FilterCategory = styled.div`
   #action-container {
     display: flex;
     align-items: center;
-    justify-content: spaced-between;
 
     svg#remove {
       flex: 0.5;

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -61,7 +61,7 @@ const FilterHeader = styled.div`
   }
 `;
 
-const FilterCategory = styled.div`
+const OldFilterCategory = styled.div`
   display: block;
   &:not(:last-of-type) {
     border-bottom: 1px solid ${props => props.theme.buttons.defaultBackgroundColor};
@@ -114,6 +114,87 @@ const FilterCategory = styled.div`
       color: ${props => props.theme.textColor};
 
       svg {
+        transform: rotateZ(180deg);
+      }
+    }
+
+    & > .content {
+      visibility: visible;
+      max-height: 250px;
+      padding: 1rem;
+    }
+  }
+`;
+
+const FilterCategory = styled.div`
+  display: block;
+  &:not(:last-of-type) {
+    border-bottom: 1px solid ${props => props.theme.buttons.defaultBackgroundColor};
+  }
+
+  #button-container {
+    display: flex;
+    align-items: center;
+
+    #close {
+      margin-right: 1em;
+      margin-left: 1em;
+      flex: 1;
+    }
+
+    #toggle {
+      margin-right: 1em;
+      transition: all 0.15s ease;
+      flex: 1;
+    }
+  }
+
+  #button-container > .category {
+    padding: 0.75rem 1rem;
+    flex: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: ${props => props.theme.pages.p};
+    transition: all 0.15s ease;
+
+    &:hover {
+      color: ${props => props.theme.textColor};
+    }
+
+    span {
+      flex: 1;
+
+      &.active {
+        color: ${props => props.theme.textColor};
+        font-weight: 600;
+      }
+    }
+  }
+
+  & > .content {
+    visibility: hidden;
+    max-height: 0;
+    padding: 0 1rem;
+    transition: all 0.15s ease;
+    overflow: hidden;
+    background: ${props => props.theme.backgroundColor};
+
+    label {
+      color: ${props => props.theme.textColor};
+      font-weight: normal;
+      font-size: 0.9rem;
+    }
+  }
+
+  &.open {
+    #button-container > .category {
+      color: ${props => props.theme.textColor};
+    }
+
+    #button-container {
+      #toggle {
         transform: rotateZ(180deg);
       }
     }
@@ -179,11 +260,14 @@ export const FilterDropdown: FC<{
 
         {filters.map(filter => (
           <FilterCategory key={filter.attribute} className={openFilter === filter ? 'open' : ''}>
-            <div role='button' tabIndex={-1} className='category' onClick={() => toggleCategory(filter)}>
-              <span className={activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : ''}>
-                {filter.attributeLabel}
-              </span>
-              <FontAwesomeIcon icon='chevron-down' />
+            <div id='button-container'>
+              <div role='button' tabIndex={-1} className='category' onClick={() => toggleCategory(filter)}>
+                <span className={activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : ''}>
+                  {filter.attributeLabel}
+                </span>
+              </div>
+              <FontAwesomeIcon id='close' icon='xmark' />
+              <FontAwesomeIcon id='toggle' icon='chevron-down' />
             </div>
 
             <div className='content'>

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -72,16 +72,9 @@ const FilterCategory = styled.div`
     align-items: center;
 
     svg.remove {
-      flex: 0.5;
-      padding: 0.5rem 0;
-      border-radius: ${props => props.theme.borderRadius};
+      padding: 0.5rem 0.75rem;
       display: none;
       cursor: pointer;
-
-      &:hover {
-        background-color: ${props => props.theme.noticeBackgroundColor};
-        color: ${props => props.theme.noticeTextColor};
-      }
 
       &.active {
         display: inline-block;
@@ -89,15 +82,15 @@ const FilterCategory = styled.div`
     }
 
     svg.toggle {
+      padding: 0.5rem 0.75rem;
       transition: all 0.15s ease;
-      flex: 0.5;
-      padding: 0.75rem 0;
+      min-width: 2rem;
       cursor: pointer;
     }
 
     .category {
       padding: 0.75rem 1rem;
-      flex: 2;
+      flex: 1;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/common/components/DataTable/FilterDropdown.tsx
+++ b/src/common/components/DataTable/FilterDropdown.tsx
@@ -61,85 +61,20 @@ const FilterHeader = styled.div`
   }
 `;
 
-const OldFilterCategory = styled.div`
-  display: block;
-  &:not(:last-of-type) {
-    border-bottom: 1px solid ${props => props.theme.buttons.defaultBackgroundColor};
-  }
-
-  & > .category {
-    padding: 0.75rem 1rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    color: ${props => props.theme.pages.p};
-    transition: all 0.15s ease;
-
-    &:hover {
-      color: ${props => props.theme.textColor};
-    }
-
-    span {
-      flex: 1;
-
-      &.active {
-        color: ${props => props.theme.textColor};
-        font-weight: 600;
-      }
-    }
-
-    svg {
-      transition: all 0.15s ease;
-    }
-  }
-
-  & > .content {
-    visibility: hidden;
-    max-height: 0;
-    padding: 0 1rem;
-    transition: all 0.15s ease;
-    overflow: hidden;
-    background: ${props => props.theme.backgroundColor};
-
-    label {
-      color: ${props => props.theme.textColor};
-      font-weight: normal;
-      font-size: 0.9rem;
-    }
-  }
-
-  &.open {
-    & > .category {
-      color: ${props => props.theme.textColor};
-
-      svg {
-        transform: rotateZ(180deg);
-      }
-    }
-
-    & > .content {
-      visibility: visible;
-      max-height: 250px;
-      padding: 1rem;
-    }
-  }
-`;
-
 const FilterCategory = styled.div`
   display: block;
   &:not(:last-of-type) {
     border-bottom: 1px solid ${props => props.theme.buttons.defaultBackgroundColor};
   }
 
-  #button-container {
+  #action-container {
     display: flex;
     align-items: center;
     justify-content: spaced-between;
 
-    svg#clear {
-      flex: .5;
-      padding: 0.50rem 0;
+    svg#remove {
+      flex: 0.5;
+      padding: 0.5rem 0;
       border-radius: ${props => props.theme.borderRadius};
       display: none;
       cursor: pointer;
@@ -156,32 +91,32 @@ const FilterCategory = styled.div`
 
     svg#toggle {
       transition: all 0.15s ease;
-      flex: .5;
+      flex: 0.5;
       padding: 0.75rem 0;
       cursor: pointer;
     }
-  }
 
-  #button-container > .category {
-    padding: 0.75rem 1rem;
-    flex: 2;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    color: ${props => props.theme.pages.p};
-    transition: all 0.15s ease;
+    .category {
+      padding: 0.75rem 1rem;
+      flex: 2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      color: ${props => props.theme.pages.p};
+      transition: all 0.15s ease;
 
-    &:hover {
-      color: ${props => props.theme.textColor};
-    }
-
-    span {
-      flex: 1;
-
-      &.active {
+      &:hover {
         color: ${props => props.theme.textColor};
-        font-weight: 600;
+      }
+
+      span {
+        flex: 1;
+
+        &.active {
+          color: ${props => props.theme.textColor};
+          font-weight: 600;
+        }
       }
     }
   }
@@ -202,11 +137,11 @@ const FilterCategory = styled.div`
   }
 
   &.open {
-    #button-container > .category {
+    #action-container > .category {
       color: ${props => props.theme.textColor};
     }
 
-    #button-container {
+    #action-container {
       svg#toggle {
         transform: rotateZ(180deg);
       }
@@ -263,13 +198,13 @@ export const FilterDropdown: FC<{
 
   const checkIfActiveFilter = (filter: FilterInfo): string => {
     return activeFilters.filter(a => a.attr === filter.attribute).length ? 'active' : '';
-  } 
+  };
 
   const handleFilterRemoval = (filter: FilterInfo) => {
     const filterToRemove = activeFilters.filter(a => a.attr === filter.attribute)[0];
 
     removeFilter(filterToRemove.attr, filterToRemove.op);
-  }
+  };
 
   return (
     <StyledDropdown className={show ? 'show' : ''} ref={dropdownContainerRef}>
@@ -283,13 +218,16 @@ export const FilterDropdown: FC<{
 
         {filters.map(filter => (
           <FilterCategory key={filter.attribute} className={openFilter === filter ? 'open' : ''}>
-            <div id='button-container'>
+            <div id='action-container'>
               <div role='button' tabIndex={-1} className='category' onClick={() => toggleCategory(filter)}>
-                <span className={checkIfActiveFilter(filter)}>
-                  {filter.attributeLabel}
-                </span>
+                <span className={checkIfActiveFilter(filter)}>{filter.attributeLabel}</span>
               </div>
-              <FontAwesomeIcon id='clear' className={checkIfActiveFilter(filter)} icon='xmark' onClick={() => handleFilterRemoval(filter)} />
+              <FontAwesomeIcon
+                id='remove'
+                className={checkIfActiveFilter(filter)}
+                icon='xmark'
+                onClick={() => handleFilterRemoval(filter)}
+              />
               <FontAwesomeIcon id='toggle' icon='chevron-down' onClick={() => toggleCategory(filter)} />
             </div>
 


### PR DESCRIPTION
## Changes
1. Added a 'x' button to the left of the expand/collapse button that's a part of the FilterCategory component. It will only be shown when a filter is active. When clicked, the associated filter will be removed.
2. Edited the styling of the FilterCategory styled component
3. Corrected a bug in the `DataTableSearchAndFilters` component that was causing the following situation: `if you had two filters that used the same operation and you removed one of them, it would remove both of them.`

## Purpose
Filters can now be de-selected individually

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo.
2. Add 2 filters and try to remove one of them.

## Screenshots

https://user-images.githubusercontent.com/2876874/196542812-ea24cebd-7edb-43c6-8a63-bb0675e039b5.mov