### PR TITLE
Fix profile picture error message

### DIFF
--- a/src/common/error/utilities.ts
+++ b/src/common/error/utilities.ts
@@ -1,5 +1,9 @@
 import { FieldValues, UseFormSetError } from 'react-hook-form';
 
+export function isKeyOfObject<T>(key: string | number | symbol, obj: T): key is keyof T {
+  return key in obj;
+}
+
 export const isObject = (value: unknown): value is Record<string, unknown> => {
   return value !== null && typeof value === 'object';
 };

--- a/src/features/user-profile/hooks/useUpdateProfilePicture.ts
+++ b/src/features/user-profile/hooks/useUpdateProfilePicture.ts
@@ -5,6 +5,11 @@ import { authSlice, AuthState } from '../../auth/authSlice';
 import * as notificationService from 'common/services/notification';
 import { useUpdateProfilePictureMutation, UpdateProfilePictureRequest } from 'common/api/userApi';
 import * as authLocalStorage from '../../auth/authLocalStorage';
+import { isObject, isStringArray } from 'common/error/utilities';
+
+export function isKeyOfObject<T>(key: string | number | symbol, obj: T): key is keyof T {
+  return key in obj;
+}
 
 export const useUpdateProfilePicture = () => {
   const dispatch = useAppDispatch();
@@ -24,7 +29,14 @@ export const useUpdateProfilePicture = () => {
         }
       } catch (error) {
         if (isFetchBaseQueryError(error)) {
-          handleApiError(error);
+          if (error.data && isObject(error.data) && isKeyOfObject('file', error.data)) {
+            const fileErrorMessages = error.data.file;
+            if (isStringArray(fileErrorMessages)) {
+              notificationService.showErrorMessage(fileErrorMessages.join(' '));
+            }
+          } else {
+            handleApiError(error);
+          }
         } else {
           notificationService.showErrorMessage('Unable to upload profile picture.');
           throw error;

--- a/src/features/user-profile/hooks/useUpdateProfilePicture.ts
+++ b/src/features/user-profile/hooks/useUpdateProfilePicture.ts
@@ -5,11 +5,7 @@ import { authSlice, AuthState } from '../../auth/authSlice';
 import * as notificationService from 'common/services/notification';
 import { useUpdateProfilePictureMutation, UpdateProfilePictureRequest } from 'common/api/userApi';
 import * as authLocalStorage from '../../auth/authLocalStorage';
-import { isObject, isStringArray } from 'common/error/utilities';
-
-export function isKeyOfObject<T>(key: string | number | symbol, obj: T): key is keyof T {
-  return key in obj;
-}
+import { isObject, isStringArray, isKeyOfObject } from 'common/error/utilities';
 
 export const useUpdateProfilePicture = () => {
   const dispatch = useAppDispatch();


### PR DESCRIPTION
Profile picture uploading now respects server side validations.

![image](https://user-images.githubusercontent.com/2287977/196553758-72f30ba7-48ff-4328-acc3-6d61b71ce795.png)

We added a server side validation for file size, in https://github.com/Shift3/dj-starter/pull/42 and this branch respects and displays that validation correctly.