### PR TITLE
Fixes the pagination text that is shown when there are no results

### DIFF
--- a/src/common/components/DataTable/Paginator.tsx
+++ b/src/common/components/DataTable/Paginator.tsx
@@ -68,7 +68,7 @@ export const Paginator: FC<Props> = ({
         {/* Display the range of results currently showing */}
         <Col className='d-flex justify-content-end align-items-center'>
           <span className='text-muted' style={{ marginRight: '10px' }}>
-            {rangeStart} - {rangeEnd} of {count}
+            {count !== 0 ? `${rangeStart} - ${rangeEnd} of ${count}` : 'No Results'}
           </span>
           <Button variant='link' disabled={!hasPreviousPage} onClick={onPreviousPageClick}>
             <FontAwesomeIcon icon={faChevronLeft} />{' '}


### PR DESCRIPTION
## Changes
1. Instead of showing 0 - 0 of 0, 'No Results' will be shown when there are no results via searching or filtering.

## Purpose
Fixes the No Results pagination text

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo.
2. Go to the user list and try searching for something that doesn't exist

## Screenshots

<img width="1383" alt="no results pagination" src="https://user-images.githubusercontent.com/2876874/196773189-d5509300-6dce-44f9-a42a-3659bd8a56cb.png">