### PR TITLE
Modifies <NoContent /> to be more usable.

### DIFF
--- a/src/common/components/LoadingSpinner/WithLoadingOverlay.tsx
+++ b/src/common/components/LoadingSpinner/WithLoadingOverlay.tsx
@@ -36,7 +36,7 @@ export const WithLoadingOverlay: FC<PropsWithChildren<Props>> = ({ isLoading, ch
           </StyledLoadingSpinner>
         </CenteredSpinnerContainer>
       ) : null}
-      {isInitialLoad ? <NoContent /> : children}
+      {isInitialLoad ? <NoContent title='' /> : children}
     </DimmableContent>
   );
 };

--- a/src/common/styles/utilities.tsx
+++ b/src/common/styles/utilities.tsx
@@ -1,6 +1,8 @@
 import { Alert, Badge } from 'react-bootstrap';
 import styled, { css } from 'styled-components';
-import { FC, PropsWithChildren } from 'react';
+import { FC, PropsWithChildren, ReactNode } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
 export const SubtleBadge = styled(Badge)<{
   variant?: 'warning' | 'danger' | 'secondary' | 'info';
@@ -88,7 +90,7 @@ export const CircularImg = styled.img<{
   box-shadow: rgba(14, 30, 37, 0.12) 0px 2px 4px 0px, rgba(14, 30, 37, 0.32) 0px 2px 16px 0px;
 `;
 
-export const NoContent = styled.div`
+const NoContentStyles = styled.div`
   min-height: 320px;
   display: flex;
   align-items: center;
@@ -101,6 +103,20 @@ export const NoContent = styled.div`
     margin-bottom: 0.5rem;
   }
 `;
+
+export const NoContent: FC<{
+  title: string;
+  icon?: IconDefinition;
+  extra?: ReactNode;
+}> = ({ title, icon, extra }) => {
+  return (
+    <NoContentStyles>
+      {icon && <FontAwesomeIcon icon={icon} className='text-muted' size='2x' />}
+      <p className='lead mb-0'>{title}</p>
+      {extra}
+    </NoContentStyles>
+  );
+};
 
 const StagingBanner = styled(Alert).attrs({
   variant: 'warning',

--- a/src/features/agent-dashboard/pages/AgentListView.tsx
+++ b/src/features/agent-dashboard/pages/AgentListView.tsx
@@ -1,4 +1,3 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useGetAgentsQuery } from 'common/api/agentApi';
 import { DataTable } from 'common/components/DataTable';
 import { DataTableSearchAndFilters } from 'common/components/DataTable/DataTableSearchAndFilters';
@@ -16,6 +15,7 @@ import { AgentTableItem, useAgentTableData } from '../hooks/useAgentTableData';
 import { Trans } from 'react-i18next';
 import { StringFilter } from 'common/components/DataTable/Filters';
 import { FilterInfo } from 'common/components/DataTable/FilterDropdown';
+import { faStethoscope } from '@fortawesome/free-solid-svg-icons';
 
 export const AgentListView: FC = () => {
   const navigate = useNavigate();
@@ -111,17 +111,18 @@ export const AgentListView: FC = () => {
                 }}
               />
             ) : (
-              <NoContent>
-                <FontAwesomeIcon className='text-muted' size='2x' icon={['fas', 'stethoscope']} />
-                <p className='lead mb-0'>No Agents</p>
-
-                <HasPermission perform='agent:create'>
-                  <p className='text-muted'>Get started by creating a new agent.</p>
-                  <Link to='/agents/create-agent'>
-                    <Button variant='default'>Add Agent</Button>
-                  </Link>
-                </HasPermission>
-              </NoContent>
+              <NoContent
+                title='No Agents'
+                icon={faStethoscope}
+                extra={
+                  <HasPermission perform='agent:create'>
+                    <p className='text-muted'>Get started by creating a new agent.</p>
+                    <Link to='/agents/create-agent'>
+                      <Button variant='default'>Add Agent</Button>
+                    </Link>
+                  </HasPermission>
+                }
+              />
             )}
           </WithLoadingOverlay>
         </Card.Body>

--- a/src/features/notifications/components/UnreadNotifications.tsx
+++ b/src/features/notifications/components/UnreadNotifications.tsx
@@ -1,4 +1,4 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBell } from '@fortawesome/free-solid-svg-icons';
 import { useMarkAllReadMutation } from 'common/api/notificationApi';
 import { LoadingButton } from 'common/components/LoadingButton';
 import { NoContent } from 'common/styles/utilities';
@@ -28,10 +28,7 @@ export const UnreadNotifications: FC = () => {
     <>
       {!isNotificationsLoading && notifications.length === 0 ? (
         <Card>
-          <NoContent>
-            <FontAwesomeIcon className='text-muted' size='2x' icon={['fas', 'bell']} />
-            <p className='lead mb-0'>No Notifications</p>
-          </NoContent>
+          <NoContent title='No Notifications' icon={faBell} />
         </Card>
       ) : null}
 


### PR DESCRIPTION
NoContent before was hardly more than a style wrapper. This modifies it to fit it's actual purpose more precisely, which is to display a no content block for places in the application where there is no content to display.

Users can use the `extra` prop to display whatever other things they want in the no content block, such as buttons, forms, etc.
