### PR TITLE
Adds the current language to the Accept-Language header

### DIFF
--- a/src/common/api/customBaseQuery.ts
+++ b/src/common/api/customBaseQuery.ts
@@ -10,9 +10,13 @@ const baseQuery = fetchBaseQuery({
   baseUrl: environment.apiRoute,
   prepareHeaders: (headers: Headers, { getState }) => {
     const { token } = (getState() as RootState).auth;
+    const currentLanguage = localStorage.getItem('language');
+      
+    console.log('current language:', currentLanguage);
 
-    if (token) {
+    if (token && currentLanguage) {
       headers.set('authorization', `Token ${token}`);
+      headers.set('accept-language', currentLanguage);
     }
 
     return headers;

--- a/src/common/api/customBaseQuery.ts
+++ b/src/common/api/customBaseQuery.ts
@@ -12,8 +12,11 @@ const baseQuery = fetchBaseQuery({
     const { token } = (getState() as RootState).auth;
     const currentLanguage = localStorage.getItem('language');
 
-    if (token && currentLanguage) {
+    if (token) {
       headers.set('authorization', `Token ${token}`);
+    }
+
+    if (currentLanguage) {
       headers.set('accept-language', currentLanguage);
     }
 

--- a/src/common/api/customBaseQuery.ts
+++ b/src/common/api/customBaseQuery.ts
@@ -11,8 +11,6 @@ const baseQuery = fetchBaseQuery({
   prepareHeaders: (headers: Headers, { getState }) => {
     const { token } = (getState() as RootState).auth;
     const currentLanguage = localStorage.getItem('language');
-      
-    console.log('current language:', currentLanguage);
 
     if (token && currentLanguage) {
       headers.set('authorization', `Token ${token}`);


### PR DESCRIPTION
## Changes
1. Adds the currently selected language to the Accept-Language header

## Purpose
Adds the current language to the Accept-Language header so that the backend can identify the language for translation purposes (ex. return error messages in the user's language)

## Learning
[(MDN) Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the jgg-translated-backend-error-msgs branch of the dj_starter_demo repo. (make sure you set up the branch correctly by following the testing steps in the associated [PR](https://github.com/Shift3/dj-starter/pull/43))
2. Create another user and change the language to Spanish
3. Try to change the new user's email to the email of the original admin user. You should get a translated error message under the text input box (refer to the screenshot below).

## Screenshots

![change-email-validation-error](https://user-images.githubusercontent.com/2876874/198158438-d2aad992-d26a-4c0a-bbce-ffa2975a2d0f.png)