### PR TITLE
Added `localStorage` to dark/light mode theming

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -24,20 +24,26 @@ import { GlobalStyle } from '../GlobalStyle';
 export const ThemeContext = createContext({
   theme: 'light',
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  toggle: () => {},
+  toggleTheme: () => {},
 });
 
 export const App: FC = () => {
   const [theme, setTheme] = useState('light');
 
   const themeProviderValue = useMemo(() => {
-    const toggle = () => {
-      return theme === 'light' ? setTheme('dark') : setTheme('light');
+    const toggleTheme = () => {
+      if (theme === 'light') {
+        window.localStorage.setItem('theme', 'dark');
+        setTheme('dark');
+      } else {
+        window.localStorage.setItem('theme', 'light');
+        setTheme('light');
+      }
     };
 
     return {
       theme,
-      toggle,
+      toggleTheme,
     };
   }, [theme]);
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,7 +28,7 @@ export const ThemeContext = createContext({
 });
 
 export const App: FC = () => {
-  const [theme, setTheme] = useState('light');
+  const [theme, setTheme] = useState(localStorage.getItem('theme') || 'light');
 
   const themeProviderValue = useMemo(() => {
     const toggleTheme = () => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -23,7 +23,6 @@ import { GlobalStyle } from '../GlobalStyle';
 
 export const ThemeContext = createContext({
   theme: 'light',
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   toggleTheme: () => {},
 });
 

--- a/src/features/navbar/components/BitwiseNavbar.tsx
+++ b/src/features/navbar/components/BitwiseNavbar.tsx
@@ -255,7 +255,7 @@ export const BitwiseNavbar: FC = () => {
   const { userHasPermission } = useRbac();
   const location = useLocation();
   const navigate = useNavigate();
-  const { toggle, theme } = useTheme();
+  const { toggleTheme, theme } = useTheme();
   const { logout, isLoading } = useLogout();
   const { i18n } = useTranslation();
   const [showModal, hideModal] = useModal(
@@ -335,7 +335,7 @@ export const BitwiseNavbar: FC = () => {
             </Nav>
 
             <Nav className='justify-content-end'>
-              <NavLink onClick={() => toggle()} className='theme-toggle me-3 d-flex align-items-center'>
+              <NavLink onClick={() => toggleTheme()} className='theme-toggle me-3 d-flex align-items-center'>
                 <>{theme === 'light' ? <MoonIcon /> : <SunIcon />}</>
               </NavLink>
 

--- a/src/features/themes/ToggleSwitch.tsx
+++ b/src/features/themes/ToggleSwitch.tsx
@@ -15,11 +15,11 @@ const Switch = styled.div`
 `;
 
 export const ThemeToggle: FC = () => {
-  const { toggle, theme } = useTheme();
+  const { toggleTheme, theme } = useTheme();
 
   return (
     <div>
-      <Switch onClick={() => toggle()}>{theme === 'light' ? <MoonIcon /> : <SunIcon />}</Switch>
+      <Switch onClick={() => toggleTheme()}>{theme === 'light' ? <MoonIcon /> : <SunIcon />}</Switch>
     </div>
   );
 };


### PR DESCRIPTION
## Changes
1. Added `localStorage` to App.tsx
2. Renamed `toggle` to `themeToggle` to be more explicit.

## Purpose
The dark/light mode toggle was not persistent. By adding local storage, the theming now persists for the user, when they log off, and back in again.

## Testing
1. Pull in the changes to your local copy of this branch and run `yarn start`.
2. Make sure you are running the `dj_starter_demo` server.
3. Login and toggle the light/dark mode, log off, and then check that the selected mode persists.
