### PR TITLE
Individual Notifications can now be marked as read

### DIFF
--- a/src/common/api/notificationApi.ts
+++ b/src/common/api/notificationApi.ts
@@ -29,6 +29,13 @@ export const notificationApi = createApi({
         method: 'POST',
       }),
     }),
+
+    markRead: builder.mutation<void, number>({
+      query: notificationId => ({
+        url: `notifications/${notificationId}/mark_read/`,
+        method: 'POST',
+      }),
+    }),
   }),
 });
 
@@ -37,4 +44,5 @@ export const {
   useGetReadNotificationsQuery,
   useMarkAllReadMutation,
   useGetEventTokenQuery,
+  useMarkReadMutation,
 } = notificationApi;

--- a/src/features/notifications/components.tsx
+++ b/src/features/notifications/components.tsx
@@ -1,11 +1,45 @@
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { LoadingButton } from 'common/components/LoadingButton';
 import { AppNotification } from 'common/models/notifications';
-import { FC } from 'react';
+import { FC, PropsWithChildren } from 'react';
 import Moment from 'react-moment';
 import { Link } from 'react-router-dom';
+import { useMarkRead } from './hooks/useMarkRead';
+
+const BaseNotification: FC<
+  PropsWithChildren<{
+    title: string;
+    notification: AppNotification;
+  }>
+> = ({ title, notification, children }) => {
+  const { markRead, isLoading } = useMarkRead();
+
+  return (
+    <div key={notification.id}>
+      <div className='d-flex'>
+        <div className='flex-fill'>
+          <h1 className='fs-5 mb-0'>{title}</h1>
+          {children}
+        </div>
+
+        {!notification.read && (
+          <div className='d-flex align-items-center justify-content-center'>
+            <LoadingButton loading={isLoading} variant='default' onClick={() => markRead(notification)}>
+              {!isLoading && <FontAwesomeIcon icon={faCheck} />}
+            </LoadingButton>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
 
 export const AgentCreatedNotification: FC<{
   notification: AppNotification;
 }> = ({ notification }) => {
+  const { markRead } = useMarkRead();
+
   interface AgentCreatedData {
     userId: string;
     agentId: number;
@@ -22,15 +56,19 @@ export const AgentCreatedNotification: FC<{
   if (!isAgentCreatedNotificationData(data)) return <></>;
 
   return (
-    <div key={notification.id}>
-      <h1 className='fs-5 mb-0'>New Agent Created</h1>
+    <BaseNotification title='New Agent Created' notification={notification}>
       <p className='p-0 m-0 mb-2'>
         <Moment className='fw-normal fs-6 text-muted' fromNow>
           {notification.created}
         </Moment>
       </p>
-      <Link to={`/users/update-user/${data.userId}`}>{data.userName}</Link> created a new agent named{' '}
-      <Link to={`/agents/update-agent/${data.agentId}`}>{data.agentName}</Link>
-    </div>
+      <Link to={`/users/update-user/${data.userId}`} onClick={() => markRead(notification)}>
+        {data.userName}
+      </Link>{' '}
+      created a new agent named{' '}
+      <Link to={`/agents/update-agent/${data.agentId}`} onClick={() => markRead(notification)}>
+        {data.agentName}
+      </Link>
+    </BaseNotification>
   );
 };

--- a/src/features/notifications/components/UnreadNotifications.tsx
+++ b/src/features/notifications/components/UnreadNotifications.tsx
@@ -18,8 +18,7 @@ export const UnreadNotifications: FC = () => {
   } = useContext(NotificationContext);
 
   const [markAllRead, { isLoading }] = useMarkAllReadMutation();
-
-  const markRead = async () => {
+  const handleMarkAllRead = async () => {
     await markAllRead().unwrap();
     clear();
   };
@@ -34,7 +33,10 @@ export const UnreadNotifications: FC = () => {
 
       {notifications.length ? (
         <div className='text-end mb-3'>
-          <LoadingButton onClick={() => markRead()} loading={isLoading || isNotificationsLoading || isFetching}>
+          <LoadingButton
+            onClick={() => handleMarkAllRead()}
+            loading={isLoading || isNotificationsLoading || isFetching}
+          >
             Mark all Read
           </LoadingButton>
         </div>

--- a/src/features/notifications/context.tsx
+++ b/src/features/notifications/context.tsx
@@ -10,6 +10,7 @@ export const NotificationContext = createContext<{
   isLoading: boolean;
   getMore: () => void;
   clear: () => void;
+  remove: (notification: AppNotification) => void;
 }>({
   notifications: [],
   count: 0,
@@ -20,6 +21,8 @@ export const NotificationContext = createContext<{
   getMore: () => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   clear: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  remove: () => {},
 });
 
 export const NotificationsProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {

--- a/src/features/notifications/hooks/useMarkRead.tsx
+++ b/src/features/notifications/hooks/useMarkRead.tsx
@@ -1,0 +1,18 @@
+import { useMarkReadMutation } from 'common/api/notificationApi';
+import { AppNotification } from 'common/models/notifications';
+import { useContext } from 'react';
+import { NotificationContext } from '../context';
+
+export const useMarkRead = () => {
+  const { remove } = useContext(NotificationContext);
+  const [markReadRequest, { isLoading }] = useMarkReadMutation();
+
+  const markRead = async (notification: AppNotification) => {
+    if (!notification.read) {
+      await markReadRequest(notification.id).unwrap();
+      remove(notification);
+    }
+  };
+
+  return { markRead, isLoading };
+};


### PR DESCRIPTION
## Changes (Updated on Nov 30th)
1. Adds the individual mark read networking request
2. Made it so that clicking on either link of a notification will cause the mark_read endpoint to be called
3. Renamed the markRead method in the UnreadNotification component to handleMarkAllRead
4. Created a `BaseNotification` to standardize notification layout.
5. Created the `useMarkRead` hook to handle the individual mark read functionality
6. Adds a `remove` dispatch action to `useLiveNotifications` to remove individual notifications.
7. Fixes the infinite loading functionality in the ReadNotifications component

## Purpose
Individual Notifications can now be marked as read

## Approach
1. Besides passing the notification to the renderNotification method, the handleMarkRead method is passed as well. This is an optional parameter that was added to the renderNotification method, the AgentCreatedNotification component, and the newly added NotificationLink component. If handleMarkRead isn't undefined, then clicking on a link of an unread notification will cause the notification to be marked as read and cause the clear method to be called. 

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo.
2. Create another admin. Use that admin to create one or more agents. Log back into the original admin and then open the notifications feature. Mark one or both notifications as being read and then check out the "Read" subtab.

## Demo

https://user-images.githubusercontent.com/2876874/198729715-bd4f70ae-8978-4c6e-9c12-78c37747e1ce.mov