### PR TITLE
Moved `address` to agent model

### DIFF
--- a/src/common/api/agentApi.ts
+++ b/src/common/api/agentApi.ts
@@ -7,12 +7,31 @@ import { QueryParamsBuilder } from './queryParamsBuilder';
 
 export type CreateAgentRequest = Pick<
   Agent,
-  'description' | 'email' | 'name' | 'phoneNumber' | 'thumbnail' | 'address'
+  | 'description'
+  | 'email'
+  | 'name'
+  | 'phoneNumber'
+  | 'thumbnail'
+  | 'address1'
+  | 'address2'
+  | 'city'
+  | 'state'
+  | 'zipCode'
 >;
 
 export type UpdateAgentRequest = Pick<
   Agent,
-  'id' | 'description' | 'email' | 'name' | 'phoneNumber' | 'thumbnail' | 'address'
+  | 'id'
+  | 'description'
+  | 'email'
+  | 'name'
+  | 'phoneNumber'
+  | 'thumbnail'
+  | 'address1'
+  | 'address2'
+  | 'city'
+  | 'state'
+  | 'zipCode'
 >;
 
 export type GetAgentHistory = {

--- a/src/common/models/address.ts
+++ b/src/common/models/address.ts
@@ -1,7 +1,0 @@
-export interface Address {
-  address1: string;
-  address2: string;
-  city: string;
-  state: string;
-  zipCode: string;
-}

--- a/src/common/models/agent.ts
+++ b/src/common/models/agent.ts
@@ -1,5 +1,3 @@
-import { Address } from './address';
-
 export interface Agent {
   id: number;
   thumbnail: string;
@@ -9,5 +7,9 @@ export interface Agent {
   phoneNumber: string;
   categoryList: unknown[];
   documentList: unknown[];
-  address?: Address;
+  address1?: string;
+  address2?: string;
+  city?: string;
+  state?: string;
+  zipCode?: string;
 }


### PR DESCRIPTION
## Changes
1. Updated frontend to match the expected `agent` model from server.
2. Updated `agent` model with address fields, by adding: `address1`, `address2`, `city`, `state`, and `zipCode`.
3. Removed Address model.

## Testing

1. Pull in the changes to your local copy of this branch and run alongside the following branch on the backend `https://github.com/Shift3/dj_starter_demo/tree/chore/address-to-agent`
2. Create a new `Agent`.
3. Update an existing `Agent`.
