### PR TITLE
Added `key in props` to remove error in console

### DIFF
--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -155,19 +155,19 @@ export const DataTable = <D extends Record<string, unknown>>({
           {headerGroups.map(headerGroup => (
             <div className='tr' {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map(column => (
-                <>
+                <div key={headerGroup.id}>
                   {sortByEnabled && column.canSort ? (
                     // Add the sorting props to control sorting and sort direction indicator.
                     <div className='th' {...column.getHeaderProps(column.getSortByToggleProps())}>
                       {column.render('Header')}{' '}
-                      <SortIndicator isSorted={column.isSorted} isDesc={column.isSortedDesc} />
+                      <SortIndicator key={headerGroup.id} isSorted={column.isSorted} isDesc={column.isSortedDesc} />
                     </div>
                   ) : (
-                    <div className='th' {...column.getHeaderProps()}>
+                    <div className='th' {...column.getHeaderProps()} key={headerGroup.id}>
                       {column.render('Header')}
                     </div>
                   )}
-                </>
+                </div>
               ))}
             </div>
           ))}

--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -155,7 +155,7 @@ export const DataTable = <D extends Record<string, unknown>>({
           {headerGroups.map(headerGroup => (
             <div className='tr' {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map(column => (
-                <div key={headerGroup.id}>
+                <div key={column.id}>
                   {sortByEnabled && column.canSort ? (
                     // Add the sorting props to control sorting and sort direction indicator.
                     <div className='th' {...column.getHeaderProps(column.getSortByToggleProps())}>

--- a/src/features/navbar/components/BitwiseNavbar.tsx
+++ b/src/features/navbar/components/BitwiseNavbar.tsx
@@ -350,7 +350,9 @@ export const BitwiseNavbar: FC = () => {
                 className='me-3'
               >
                 {__languageOptions.map(option => (
-                  <NavDropdown.Item onClick={() => changeLanguage(option.value)}>{option.label}</NavDropdown.Item>
+                  <NavDropdown.Item key={option.value} onClick={() => changeLanguage(option.value)}>
+                    {option.label}
+                  </NavDropdown.Item>
                 ))}
               </NavDropdown>
 


### PR DESCRIPTION
## Changes
1. Added `key` to props in `DataTable` component.
2. Added `key` to props in `BitwiseNavbar` component.

## Purpose
To remove the console error.

## Testing
Make sure to run the backend.

1. Pull in the changes to your local copy of this branch and run `yarn start`.
2. Check that the `key in prop` console error is no longer displayed.

