### PR TITLE
Remove `any` typing in Notification component

### DIFF
--- a/src/features/notifications/components.tsx
+++ b/src/features/notifications/components.tsx
@@ -48,8 +48,7 @@ export const AgentCreatedNotification: FC<{
   }
 
   const isAgentCreatedNotificationData = (data: unknown): data is AgentCreatedData => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return !!(data as any).userName;
+    return !!(data as AgentCreatedData).userName;
   };
 
   const { data } = notification;


### PR DESCRIPTION
## Changes
1. Added typing to return data in `AgentNotification`

## Purpose
To enable the ESlint rule `[no-explicit-any - TypeScript ESLint](https://typescript-eslint.io/rules/no-explicit-any/)]`
