### PR TITLE
Fixes the network connection notification bug

### DIFF
--- a/src/common/services/notification.tsx
+++ b/src/common/services/notification.tsx
@@ -6,22 +6,8 @@ export const showSuccessMessage = (message: string): void => {
   });
 };
 
-export const showEndlessSuccessMessage = (message: string): void => {
-  toast.success(message, {
-    toastId: message,
-    autoClose: false,
-  });
-};
-
 export const showErrorMessage = (message: string): void => {
   toast.error(message, {
     toastId: message,
-  });
-};
-
-export const showEndlessErrorMessage = (message: string): void => {
-  toast.error(message, {
-    toastId: message,
-    autoClose: false,
   });
 };

--- a/src/common/services/notification.tsx
+++ b/src/common/services/notification.tsx
@@ -1,13 +1,13 @@
 import { toast } from 'react-toastify';
 
-export const showSuccessMessage = (message: string): void => {
+export const showSuccessMessage = (message: string, id?: string): void => {
   toast.success(message, {
-    toastId: message,
+    toastId: id ?? message,
   });
 };
 
-export const showErrorMessage = (message: string): void => {
+export const showErrorMessage = (message: string, id?: string): void => {
   toast.error(message, {
-    toastId: message,
+    toastId: id ?? message,
   });
 };

--- a/src/features/network-detector/components/NetworkDetector.tsx
+++ b/src/features/network-detector/components/NetworkDetector.tsx
@@ -9,14 +9,18 @@ export const NetworkDetector: FC<PropsWithChildren<unknown>> = ({ children }) =>
     setDisconnectedStatus(!navigator.onLine);
   };
 
+  const getRandomNumber = () => {
+    return new Date().valueOf().toString();
+  };
+
   useEffect(() => {
     window.addEventListener('online', handleConnectionChange);
     window.addEventListener('offline', handleConnectionChange);
 
     if (isDisconnected) {
-      notificationService.showErrorMessage('Internet Connection Lost');
+      notificationService.showErrorMessage('Internet Connection Lost', getRandomNumber());
     } else if (prevDisconnectionStatus.current) {
-      notificationService.showSuccessMessage('Internet Connection Restored');
+      notificationService.showSuccessMessage('Internet Connection Restored', getRandomNumber());
     }
 
     prevDisconnectionStatus.current = isDisconnected;

--- a/src/features/network-detector/components/NetworkDetector.tsx
+++ b/src/features/network-detector/components/NetworkDetector.tsx
@@ -14,9 +14,9 @@ export const NetworkDetector: FC<PropsWithChildren<unknown>> = ({ children }) =>
     window.addEventListener('offline', handleConnectionChange);
 
     if (isDisconnected) {
-      notificationService.showEndlessErrorMessage('Internet Connection Lost');
+      notificationService.showErrorMessage('Internet Connection Lost');
     } else if (prevDisconnectionStatus.current) {
-      notificationService.showEndlessSuccessMessage('Internet Connection Restored');
+      notificationService.showSuccessMessage('Internet Connection Restored');
     }
 
     prevDisconnectionStatus.current = isDisconnected;


### PR DESCRIPTION
## Changes
1. The disconnected and reconnected toast messages are now using the timed toast methods.
2. Added an optional `id` parameter to the timed toast methods so that the same toast type can be shown if the ids of the toast messages are different. This is used for the internet connectivity toast messages.
3. Added a `getRandomNumber` method to the NetworkDetector component in order to supply random numbers for each toast method call.
4. Deleted the endless toast messages since they are no longer being used

## Purpose
Internet connectivity toast messages are now timed, and toasts that have the same type can be shown at the same time.

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo.
2. Go into your browser's Developer Tools and toggle between the offline/online states 

## Demo

https://user-images.githubusercontent.com/2876874/206319304-b01dc858-320a-4b44-9c33-822a47461642.mov

Closes #667 