### PR TITLE
Fixes the misaligned table headers issue

### DIFF
--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -1,5 +1,5 @@
 import { SortOrder } from 'common/models/sorting';
-import { ReactElement, useEffect } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import { Column, useFlexLayout, usePagination, useSortBy, useTable } from 'react-table';
 import { Paginator } from './Paginator';
 import { SortIndicator } from './SortIndicator';
@@ -155,7 +155,7 @@ export const DataTable = <D extends Record<string, unknown>>({
           {headerGroups.map(headerGroup => (
             <div className='tr' {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map(column => (
-                <div key={column.id}>
+                <React.Fragment key={column.id}>
                   {sortByEnabled && column.canSort ? (
                     // Add the sorting props to control sorting and sort direction indicator.
                     <div className='th' {...column.getHeaderProps(column.getSortByToggleProps())}>
@@ -167,7 +167,7 @@ export const DataTable = <D extends Record<string, unknown>>({
                       {column.render('Header')}
                     </div>
                   )}
-                </div>
+                </React.Fragment>
               ))}
             </div>
           ))}


### PR DESCRIPTION
## Changes
- Re-adds the use of the fragment (previously a separate div was surrounding each of the th inside of the tr)

**Before**

![before-fragment-fix](https://user-images.githubusercontent.com/2876874/214143982-e4a70729-e238-4aa5-ad82-80229b8c9ec5.png)

**After**

![after-fragment-fix](https://user-images.githubusercontent.com/2876874/214144038-36766f3d-1519-45d8-95a4-b304a20c02a6.png)

## Purpose
Fixes the misaligned table headers issue

## Approach
- I used `git bisect` to identify the commit that caused the bug. For reference, it was a part of the following PR: #683 

## Learning
- I learned how to use git bisect. You can find documentation about it here: https://git-scm.com/docs/git-bisect
- I learned more about Fragments in React and how to add keys to them. Here's the documentation: https://reactjs.org/docs/fragments.html#keyed-fragments

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo.
2. You should see that the table headers are no longer misaligned.

## Screenshots

![table-headers-fix](https://user-images.githubusercontent.com/2876874/214144539-e5a65601-bd42-4e10-9809-71b7e43d948c.png)

