### PR TITLE
Fix - User is directed to their homepage after logging in

### DIFF
--- a/src/features/auth/hooks/useLogin.ts
+++ b/src/features/auth/hooks/useLogin.ts
@@ -29,7 +29,7 @@ export const useLogin: UseLoginHook = () => {
         const auth = { token: session.token, user: session.user };
         dispatch(authSlice.actions.userLoggedIn(auth));
         authLocalStorage.saveAuthState(auth);
-        navigate('/agents', { replace: true });
+        navigate('/', { replace: true });
       } catch (error) {
         if (isFetchBaseQueryError(error)) {
           handleApiError(error);


### PR DESCRIPTION
## Changes
1. The user is directed to their homepage (via the "/" path instead of "/agents") after logging in.

## Purpose
- A user should land on their homepage when logging into the system.

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo.
2. Sign out (if you are already logged in)
3. Sign in. You should be directed to the home page associated with your user type, i.e. Admin, Editor, or User.