### PR TITLE
Responsive tables based on Joshwin's Branch

### DIFF
--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -241,6 +241,5 @@ export const GlobalStyle = createGlobalStyle<{ theme: typeof dark }>`
         color: black;
         font-size: 1rem;
     }
-
 `;
 export default GlobalStyle;

--- a/src/common/components/DataTable/DataTable.tsx
+++ b/src/common/components/DataTable/DataTable.tsx
@@ -1,11 +1,16 @@
+import { Breakpoint, useBreakpoint } from 'common/hooks/useBreakpoint';
 import { SortOrder } from 'common/models/sorting';
 import React, { ReactElement, useEffect } from 'react';
 import { Column, useFlexLayout, usePagination, useSortBy, useTable } from 'react-table';
 import { Paginator } from './Paginator';
 import { SortIndicator } from './SortIndicator';
 
+export type ResponsiveColumn<D extends object> = Column<D> & {
+  responsive?: Breakpoint;
+};
+
 export type DataTableProps<D extends Record<string, unknown>> = {
-  columns: Column<D>[];
+  columns: ResponsiveColumn<D>[];
   data: D[];
   onRowClick?: (item: D) => void;
   pagination?: {
@@ -147,6 +152,14 @@ export const DataTable = <D extends Record<string, unknown>>({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pagination?.page]);
+
+  const { breakpoint, isLessThan } = useBreakpoint();
+
+  useEffect(() => {
+    tableInstance.setHiddenColumns(
+      columns.filter(c => c.responsive && isLessThan(breakpoint, c.responsive)).map(c => c.accessor) as string[],
+    );
+  }, [breakpoint, columns, isLessThan, tableInstance]);
 
   return (
     <div className='d-flex flex-column'>

--- a/src/common/hooks/useBreakpoint.ts
+++ b/src/common/hooks/useBreakpoint.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+// Breakpoints and Responsiveness
+export const useBreakpoint = () => {
+  const [size, setSize] = useState<Breakpoint>('md');
+  useEffect(() => {
+    const determineSize = () => {
+      const width = window.innerWidth;
+      if (width >= 1400) {
+        setSize('xl');
+      } else if (width >= 1200) {
+        setSize('lg');
+      } else if (width >= 992) {
+        setSize('md');
+      } else if (width >= 768) {
+        setSize('sm');
+      } else {
+        setSize('xs');
+      }
+    };
+
+    determineSize();
+
+    const listener = () => {
+      determineSize();
+    };
+    window.addEventListener('resize', listener);
+
+    return () => {
+      window.removeEventListener('resize', listener);
+    };
+  }, [setSize]);
+
+  const isLessThan = useCallback((a: Breakpoint, b: Breakpoint) => {
+    const hiearchy: Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl'];
+    return hiearchy.indexOf(a) < hiearchy.indexOf(b);
+  }, []);
+
+  return {
+    breakpoint: size,
+    isLessThan,
+  };
+};

--- a/src/features/farm-dashboard/hooks/useFarmTableData.tsx
+++ b/src/features/farm-dashboard/hooks/useFarmTableData.tsx
@@ -17,12 +17,7 @@ export type FarmTableItem = {
   actions: ActionButtonProps[];
 };
 
-export type UseFarmTableData = (agents?: Farm[]) => {
-  columns: ResponsiveColumn<FarmTableItem>[];
-  data: FarmTableItem[];
-};
-
-export const useFarmTableData: UseFarmTableData = (farms = []) => {
+export const useFarmTableData = (farms: Farm[] = []) => {
   const { userHasPermission } = useRbac();
 
   const [deleteFarm] = useDeleteFarmMutation();

--- a/src/features/farm-dashboard/hooks/useFarmTableData.tsx
+++ b/src/features/farm-dashboard/hooks/useFarmTableData.tsx
@@ -1,4 +1,5 @@
 import { useDeleteFarmMutation } from 'common/api/farmApi';
+import { ResponsiveColumn } from 'common/components/DataTable';
 import { SimpleConfirmModal } from 'common/components/SimpleConfirmModal';
 import { useModalWithData } from 'common/hooks/useModalWithData';
 import { Farm } from 'common/models';
@@ -6,7 +7,6 @@ import * as notificationService from 'common/services/notification';
 import { ActionButton, ActionButtonProps } from 'common/styles/button';
 import { useRbac } from 'features/rbac';
 import { useMemo } from 'react';
-import { Column } from 'react-table';
 import { formatPhoneNumber } from 'utils/phone';
 
 export type FarmTableItem = {
@@ -17,8 +17,8 @@ export type FarmTableItem = {
   actions: ActionButtonProps[];
 };
 
-export type UseFarmTableData = (farms?: Farm[]) => {
-  columns: Column<FarmTableItem>[];
+export type UseFarmTableData = (agents?: Farm[]) => {
+  columns: ResponsiveColumn<FarmTableItem>[];
   data: FarmTableItem[];
 };
 
@@ -60,12 +60,14 @@ export const useFarmTableData: UseFarmTableData = (farms = []) => {
   );
 
   // Set up columns and headers
-  const columns: Column<FarmTableItem>[] = useMemo(
+
+  const columns: ResponsiveColumn<FarmTableItem>[] = useMemo(
     () => [
       { accessor: 'name', Header: 'Farm Name' },
-      { accessor: 'email', Header: 'Email' },
+      { accessor: 'email', responsive: 'sm', Header: 'Email' },
       {
         accessor: 'phoneNumber',
+        responsive: 'md',
         Header: 'Phone Number',
         Cell: ({ value }) => <span>{formatPhoneNumber(value)}</span>,
       },

--- a/src/features/user-dashboard/hooks/useUserTableData.tsx
+++ b/src/features/user-dashboard/hooks/useUserTableData.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { handleApiError, isFetchBaseQueryError } from 'common/api/handleApiError';
 import { useDeleteUserMutation, useForgotPasswordMutation, useResendActivationEmailMutation } from 'common/api/userApi';
+import { ResponsiveColumn } from 'common/components/DataTable';
 import { SimpleConfirmModal } from 'common/components/SimpleConfirmModal';
 import { useModalWithData } from 'common/hooks/useModalWithData';
 import { Image, Role, RoleType, User } from 'common/models';
@@ -156,7 +157,7 @@ export const useUserTableData: UseUserTableData = (users = []) => {
   };
 
   // Set up columns and headers
-  const columns: Column<UserTableItem>[] = useMemo(
+  const columns: ResponsiveColumn<UserTableItem>[] = useMemo(
     () => [
       {
         accessor: 'lastName',
@@ -193,6 +194,7 @@ export const useUserTableData: UseUserTableData = (users = []) => {
       {
         accessor: 'activatedAt',
         Header: 'Activated',
+        responsive: 'md',
         Cell: ({ value: activatedAt }) => (
           <>
             {activatedAt instanceof Date ? (

--- a/src/features/user-dashboard/hooks/useUserTableData.tsx
+++ b/src/features/user-dashboard/hooks/useUserTableData.tsx
@@ -12,7 +12,6 @@ import { UserProfilePicture } from 'features/navbar/components/UserProfilePictur
 import { useRbac } from 'features/rbac';
 import { useMemo } from 'react';
 import { Button } from 'react-bootstrap';
-import { Column } from 'react-table';
 
 export type UserTableItem = {
   id: string;
@@ -25,12 +24,7 @@ export type UserTableItem = {
   actions: ActionButtonProps[];
 };
 
-export type UseUserTableData = (farms?: User[]) => {
-  columns: Column<UserTableItem>[];
-  data: UserTableItem[];
-};
-
-export const useUserTableData: UseUserTableData = (users = []) => {
+export const useUserTableData = (users: User[] = []) => {
   const { userHasPermission } = useRbac();
 
   const [deleteUser] = useDeleteUserMutation();

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,67 +732,67 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@sentry/browser@7.41.0":
-  version "7.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.41.0.tgz#f4e789417e3037cbc9cd15f3a000064b1873b964"
-  integrity sha512-ZEtgTXPOHZ9/Qn42rr9ZAPTKCV6fAjyDC4FFWMGP4HoUqJqr2woRddP9O5n1jvjsoIPAFOmGzbCuZwFrPVVnpQ==
+"@sentry/browser@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.42.0.tgz#357731e5ab65a226c98370f9e487fe48cadab765"
+  integrity sha512-xTwfvrQPmYTkAvGivoJFadPLKLDS2N57D/18NA1gcrnF8NwR+I28x3I9ziVUiMCYX+6nJuqBNlMALAEPbb2G5A==
   dependencies:
-    "@sentry/core" "7.41.0"
-    "@sentry/replay" "7.41.0"
-    "@sentry/types" "7.41.0"
-    "@sentry/utils" "7.41.0"
+    "@sentry/core" "7.42.0"
+    "@sentry/replay" "7.42.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
     tslib "^1.9.3"
 
-"@sentry/core@7.41.0":
-  version "7.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.41.0.tgz#a4a8291ef4e65f40c28fc38318e7dae721d5d609"
-  integrity sha512-yT3wl3wMfPymstIZRWNjuov4xhieIEPD0z9MIW9VmoemqkD5BEZsgPuvGaVIyQVMyx61GsN4H4xd0JCyNqNvLg==
+"@sentry/core@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.42.0.tgz#3333a1b868e8e69b6fbc8e5a9e9281be49321ac7"
+  integrity sha512-vNcTyoQz5kUXo5vMGDyc5BJMO0UugPvMfYMQVxqt/BuDNR30LVhY+DL2tW1DFZDvRvyn5At+H7kSTj6GFrANXQ==
   dependencies:
-    "@sentry/types" "7.41.0"
-    "@sentry/utils" "7.41.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
     tslib "^1.9.3"
 
 "@sentry/react@^7.12.1":
-  version "7.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.41.0.tgz#bde46a49ff7622357239b7fd86c372459fcbde97"
-  integrity sha512-Ajt71pa6Nj4h3hLi2LeS25miVqMv1Zt5NPX5QpSvlPxFRJiIYPOQRWRt0r1pMYR5wD+Y54hJDue+EcWS1H3AKA==
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.42.0.tgz#7662faef398032f253fe5b174860e1ec5f76ddd5"
+  integrity sha512-DOGK+vuSZq5lTiqVU6wVay0AUMjtSPZu25gzLIXntfoqw36CLUswP7ew61+Tas6tpXDdf4lR3uxJRwySiQLopw==
   dependencies:
-    "@sentry/browser" "7.41.0"
-    "@sentry/types" "7.41.0"
-    "@sentry/utils" "7.41.0"
+    "@sentry/browser" "7.42.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/replay@7.41.0":
-  version "7.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.41.0.tgz#73168d659b0e78ca58574831a6672a77ce9727ee"
-  integrity sha512-/vxuO17AysCoBbCl9wCwjsCFBD4lEbYgfC1GJm8ayWwPU1uhvZcEx6reUwi0rEFpWYGHSHh3+gi+QsOcY/EmnQ==
+"@sentry/replay@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.42.0.tgz#03be2bdab35e0f2d4e415a770c23d50dba8d73b5"
+  integrity sha512-81HQm20hrW0+0eZ5sZf8KsSekkAlI0/u/M+9ZmOn2bHpGihqAM/O/lrXhTzaRXdpX/9NSwSCGY9k7LIRNMKaEQ==
   dependencies:
-    "@sentry/core" "7.41.0"
-    "@sentry/types" "7.41.0"
-    "@sentry/utils" "7.41.0"
+    "@sentry/core" "7.42.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
 
 "@sentry/tracing@^7.12.1":
-  version "7.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.41.0.tgz#28f57667a13b95cb8bce5af0809e7727b645e6b7"
-  integrity sha512-zh1ceuwQ8NzE5n8r4y78QrYD/alJl4qlkiEX9lAL6PnLMWJkVWM02BBu+x75yPFWSSDfDA/kZ9WqKkHNdjGpDw==
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.42.0.tgz#bcdac21e1cb5f786465e6252625bd4bf0736e631"
+  integrity sha512-0veGu3Ntweuj1pwWrJIFHmVdow4yufCreGIhsNDyrclwOjaTY3uI8iA6N62+hhtxOvqv+xueB98K1DvT5liPCQ==
   dependencies:
-    "@sentry/core" "7.41.0"
-    "@sentry/types" "7.41.0"
-    "@sentry/utils" "7.41.0"
+    "@sentry/core" "7.42.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
     tslib "^1.9.3"
 
-"@sentry/types@7.41.0":
-  version "7.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.41.0.tgz#3d53432a3d7693a31b606d3083ab9203c56f5aec"
-  integrity sha512-4z9VdObynwd64i0VHCqkeIAHmsFzapL21qN41Brzb7jY/eGxjn/0rxInDGH+vkoE9qacGqiYfWj4vRNPLsC/bw==
+"@sentry/types@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.42.0.tgz#e5019cd41a8c4a98c296e2ff28d6adab4b2eb14e"
+  integrity sha512-Ga0xaBIR/peuXQ88hI9a5TNY3GLNoH8jpsgPaAjAtRHkLsTx0y3AR+PrD7pUysza9QjvG+Qux01DRvLgaNKOHA==
 
-"@sentry/utils@7.41.0":
-  version "7.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.41.0.tgz#54224dba668dd8c8feb0ff1b4f39938b8fdefd3b"
-  integrity sha512-SL+MGitvkakbkrOTb48rDuJp9GYx/veB6EOzYygh49+zwz4DGM7dD4/rvf/mVlgmXUzPgdGDgkVmxgX3nT7I7g==
+"@sentry/utils@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.42.0.tgz#fcffd0404836cb56975fbef9e889a42cc55de596"
+  integrity sha512-cBiDZVipC+is+IVgsTQLJyZWUZQxlLZ9GarNT+XZOZ5BFh0acFtz88hO6+S7vGmhcx2aCvsdC9yb2Yf+BphK6Q==
   dependencies:
-    "@sentry/types" "7.41.0"
+    "@sentry/types" "7.42.0"
     tslib "^1.9.3"
 
 "@swc/helpers@^0.4.14":
@@ -1463,9 +1463,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001449:
-  version "1.0.30001462"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz#b2e801e37536d453731286857c8520d3dcee15fe"
-  integrity sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==
+  version "1.0.30001464"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001464.tgz#888922718df48ce5e33dcfe1a2af7d42676c5eb7"
+  integrity sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -1993,9 +1993,9 @@ ejs@^3.1.5:
     jake "^10.8.5"
 
 electron-to-chromium@^1.4.284:
-  version "1.4.324"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.324.tgz#0cff81794e6c48efbb0b029224968621230d8ace"
-  integrity sha512-m+eBs/kh3TXnCuqDF6aHLLRwLK2U471JAbZ1KYigf0TM96fZglxv0/ZFBvyIxnLKsIWUoDiVnHTA2mhYz1fqdA==
+  version "1.4.325"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.325.tgz#7b97238a61192d85d055d97f3149832b3617d37b"
+  integrity sha512-K1C03NT4I7BuzsRdCU5RWkgZxtswnKDYM6/eMhkEXqKu4e5T+ck610x3FPzu1y7HVFSiQKZqP16gnJzPpji1TQ==
 
 elliptic@^6.5.3:
   version "6.5.4"


### PR DESCRIPTION
This branch adds responsive tables by adding a `responsive: Breakpoint` option to the column definitions.

For example:

```typescript
{ accessor: 'email', responsive: 'sm', Header: 'Email' },
```

Means that this column will only show up on devices "small" and above and will be hidden on breakpoints smaller than "small"

