### PR TITLE
Version AWS Provider 

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,6 +10,13 @@ terraform {
     region  = "us-west-2"
     profile = "BWTC-Developer"
   }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
 }
 
 locals {


### PR DESCRIPTION
## Changes
1. Hard set version of aws provider.

## Purpose
To reduce potential future breakages within aws provider. Also maintains best practices around versioning/pulling outside resources.

## Approach
Keep aws provider version attached to 4.0+

## Learning
While this PR looks deceptively simple, we want to make sure nothing breaks because we are hard setting a version here. We will effectively be going from 5.8.0 -> 5.59.0. If Dashicorp is using semantic versioning then it shouldn't contain any breaking changes. However, in my experience, I have seen minor versions break within this provider...so its not a safe assumption here. 

All our modules are using [5.8.0 to test with](https://github.com/Shift3/terraform-modules/blob/main/project-tests/boilerplate-client-react-angular/main.tf#L4). Thats another conversion entirely. 

Fortunately, the aws provider upgrades _should_ no longer have breaking changes after 4.8.0. More info can be found here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade


## Pre-Testing TODOs
Run through terraform plan and make sure no breaking changes are introduced.

## Testing
_How should other contributors test this Pull Request?_

1. Pull in the changes to your local copy of this branch and restart Docker.
2. run `terraform plan`
3. see no hard changes within the infrastructure
4. run `terraform apply`
5. No errors should pop up

### Closes #723
