### PR TITLE
Users can no longer change their own role

### DIFF
--- a/src/common/components/CustomSelect.tsx
+++ b/src/common/components/CustomSelect.tsx
@@ -8,6 +8,7 @@ type Props<T> = {
   placeholder?: string;
   isLoading?: boolean;
   isInvalid?: boolean;
+  isDisabled?: boolean;
   // Resolves option data to a string to be displayed as the label
   getOptionLabel?: (option: T) => string;
   // Resolves option data to a string to compare options and specify value attributes
@@ -27,6 +28,7 @@ export const CustomSelect = <T,>({
   placeholder,
   isLoading,
   isInvalid,
+  isDisabled,
   getOptionLabel,
   getOptionValue,
   onChange,
@@ -54,6 +56,7 @@ export const CustomSelect = <T,>({
         defaultValue={defaultValue}
         placeholder={placeholder}
         isLoading={isLoading}
+        isDisabled={isDisabled}
         getOptionLabel={getOptionLabel}
         getOptionValue={getOptionValue}
         onMenuScrollToBottom={onScrollToBottom}
@@ -61,7 +64,7 @@ export const CustomSelect = <T,>({
       />
       {/* A hidden react-bootstrap select is used for the `isInvalid` state which is required in
       order for the react-bootstram `Form.Control.Feedback` component to work correctly. */}
-      <Form.Select hidden isInvalid={isInvalid} />
+      <Form.Select hidden isInvalid={isInvalid} disabled={isDisabled} />
     </>
   );
 };

--- a/src/features/user-dashboard/components/UserDetailForm.tsx
+++ b/src/features/user-dashboard/components/UserDetailForm.tsx
@@ -116,9 +116,7 @@ export const UserDetailForm: FC<Props> = ({
         <Form.Group className='mb-2' controlId='create-user-form-role'>
           <Form.Label>
             {t('role', { ns: 'common' })}
-            {isRoleSelectorDisabled && 
-                <p className='text-danger mb-0'>{t('userDetail.roleRestriction', { ns: 'translation' })}</p>
-            }
+            {isRoleSelectorDisabled && <p className='text-danger mb-0'>{t('userDetail.roleRestriction')}</p>}
           </Form.Label>
           <Controller
             control={control}
@@ -136,7 +134,7 @@ export const UserDetailForm: FC<Props> = ({
           />
           <Form.Control.Feedback type='invalid'>{errors.role?.message}</Form.Control.Feedback>
           <Form.Text className='text-muted'>
-            <Trans i18nKey="userDetail.roleInfo">For more info regarding roles...</Trans>
+            <Trans i18nKey='userDetail.roleInfo'>For more info regarding roles...</Trans>
           </Form.Text>
         </Form.Group>
 

--- a/src/features/user-dashboard/components/UserDetailForm.tsx
+++ b/src/features/user-dashboard/components/UserDetailForm.tsx
@@ -18,6 +18,7 @@ export interface Props {
   availableRoles: Role[];
   defaultValues?: Partial<FormData>;
   submitButtonLabel?: string;
+  isRoleSelectorDisabled?: boolean;
   onSubmit: (data: FormData) => void;
   serverValidationErrors: ServerValidationErrors<FormData> | null;
 }
@@ -25,6 +26,7 @@ export interface Props {
 export const UserDetailForm: FC<Props> = ({
   availableRoles,
   defaultValues = {},
+  isRoleSelectorDisabled,
   onSubmit,
   submitButtonLabel = 'Submit',
   serverValidationErrors,
@@ -112,13 +114,19 @@ export const UserDetailForm: FC<Props> = ({
           <Trans i18nKey='userDetail.accessHeading'>Access Information</Trans>
         </h5>
         <Form.Group className='mb-2' controlId='create-user-form-role'>
-          <Form.Label>{t('role', { ns: 'common' })}</Form.Label>
+          <Form.Label>
+            {t('role', { ns: 'common' })}
+            {isRoleSelectorDisabled && 
+                <p className='text-danger mb-0'>{t('userDetail.roleRestriction', { ns: 'translation' })}</p>
+            }
+          </Form.Label>
           <Controller
             control={control}
             name='role'
             render={({ field: { onChange } }) => (
               <CustomSelect<RoleOption>
                 placeholder={t('userDetail.selectRole')!}
+                isDisabled={isRoleSelectorDisabled}
                 defaultValue={{ label: defaultValues?.role?.toString() || '', value: defaultValues?.role || Role.USER }}
                 options={options}
                 onChange={option => onChange(option.value)}

--- a/src/features/user-dashboard/pages/UpdateUserView.tsx
+++ b/src/features/user-dashboard/pages/UpdateUserView.tsx
@@ -8,7 +8,7 @@ import * as notificationService from 'common/services/notification';
 import { Card, Modal } from 'react-bootstrap';
 import { PageCrumb, PageHeader, SmallContainer } from 'common/styles/page';
 import { useRbac } from 'features/rbac';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { FormData, UserDetailForm } from '../components/UserDetailForm';
 import { Trans, useTranslation } from 'react-i18next';
@@ -94,6 +94,10 @@ export const UpdateUserView: FC = () => {
     }
   }, [getUserError, navigate, userHistoryError, t]);
 
+  const isRoleSelectorDisabled = useMemo(() => {
+    return user?.id === loggedInUser?.id;
+  }, [user, loggedInUser]);
+
   const handleShowAllChanges = () => {
     showModal();
   };
@@ -151,6 +155,7 @@ export const UpdateUserView: FC = () => {
                 availableRoles={availableRoles}
                 defaultValues={user}
                 submitButtonLabel={t('save', { ns: 'common' })!}
+                isRoleSelectorDisabled={isRoleSelectorDisabled}
                 onSubmit={handleFormSubmit}
                 serverValidationErrors={formValidationErrors}
               />

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -36,7 +36,8 @@
     "heading": "User Profile",
     "accessHeading": "Access Information",
     "selectRole": "Select a role...",
-    "roleInfo": "For more information about the different roles and what they can do, see our <strong>FAQ</strong>"
+    "roleInfo": "For more information about the different roles and what they can do, see our <strong>FAQ</strong>",
+    "roleRestriction": "You cannot change your own role."
   },
   "createUser": {
     "back": "Back to User List",

--- a/src/i18n/es/translation.json
+++ b/src/i18n/es/translation.json
@@ -36,7 +36,8 @@
     "heading": "Perfil de Usuario",
     "accessHeading": "Información de Acceso",
     "selectRole": "Selecciona un rol...",
-    "roleInfo": "Para obtener más información sobre los diferentes roles y lo que pueden hacer, consulta nuestras <strong>Preguntas Frecuentes</strong>"
+    "roleInfo": "Para obtener más información sobre los diferentes roles y lo que pueden hacer, consulta nuestras <strong>Preguntas Frecuentes</strong>",
+    "roleRestriction": "No puedes cambiar tu propio rol."
   },
   "createUser": {
     "back": "Volver a la Lista de Usuarios",


### PR DESCRIPTION
## Changes
1. Adds an optional `isRoleSelectorDisabled` prop to the `UserDetailForm`. This is used to determine whether the role selector on the `UserDetailForm` should be disabled. This is used by the `UpdateUserView` in order to disable the role selector when the id of the `user` being "viewed" is the same as the id of the `loggedInUser`.
2. Adds an optional `isDisabled` prop to the `CustomSelect` component. This change supports the above functionality.
3. Adds a red "You cannot change your own role." message under the Role label on the `UserDetailForm` if the currently logged in user is looking at themself via the `UpdateUserView`.
4. Made use of our translation system in order to offer the Spanish translations for the aforementioned message

## Purpose
Users can no longer change their own role

**Note:** Only Admins will be able to experience this functionality since Non-Admin Users and Editors aren't able to view the Users tab.

## Approach
This PR restricts the user from being able to interact with the role selector if they are looking at themself via the `UpdateUserView`.

## Testing Steps

1. Pull in the changes to your local copy of this branch and run it alongside the dj_starter_demo repo. Use its jgg-user-cannot-change-role branch.
2. Create a new user
3. As an admin, view your details by clicking on yourself on the Users tab. You won't be able to edit your role.
5. As that same admin, view the details of that user that you created. You will be able to change their role.

## Screenshots

![frontend-user-role-pr-original](https://github.com/Shift3/boilerplate-client-react/assets/2876874/3d8a506a-30fb-4c2b-ad5d-979d5cb155eb)