### PR TITLE
update codeowners using GitHub Team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @DropsOfSerenity @joshwingreene @fluturecode
+* @Shift3/internal-tooling


### PR DESCRIPTION

## Changes

1. Updated Codeowners file to reference a GitHub Team

## Purpose

Codeowners referencing individuals requires extra maintenance a PR/review cycle to update, while a GitHub Team can be updated quickly by devops, ensuring more accurate permissions and security.

## Approach

Update CODEOWNERS to reference a team instead of individuals. It is currently out of date, and referencing a team will make access management simpler by removing the need to make code changes as long as the team is maintained.

## Learning
Devops is using this technique in their repos, example here: https://github.com/Shift3/terraform-modules/blob/develop/.github/CODEOWNERS

Closes #725
